### PR TITLE
Update spring-boot-starter-parent to v3.5.7 and other dependencies to new versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
@@ -35,7 +35,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -33,7 +33,7 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
           java-version: '21'

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.6</version>
     </parent>
 
     <groupId>com.czertainly</groupId>
     <artifactId>dependencies</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
 
     <name>CZERTAINLY-Dependencies</name>
     <packaging>pom</packaging>
@@ -46,20 +46,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
+        <maven.jacoco.plugin.version>0.8.14</maven.jacoco.plugin.version>
         <sonar.projectKey>CZERTAINLY_CZERTAINLY-Dependencies</sonar.projectKey>
-        <spring.data.common>3.4.3</spring.data.common>
-        <fasterxml.jackson>2.18.2</fasterxml.jackson>
-        <wiremock.version>3.10.0</wiremock.version>
-        <log4j.version>2.0.13</log4j.version>
+        <spring.data.common>3.5.5</spring.data.common>
+        <fasterxml.jackson>2.20.0</fasterxml.jackson>
+        <wiremock.version>3.13.1</wiremock.version>
+        <log4j.version>2.25.2</log4j.version>
         <kxml2.version>2.3.0</kxml2.version>
         <jaxws-rt.version>4.0.3</jaxws-rt.version>
-        <commons.net.version>3.11.1</commons.net.version>
-        <commons.configuration>1.10</commons.configuration>
-        <swagger.annotation.version>2.2.28</swagger.annotation.version>
-        <bouncycastle.version>1.80</bouncycastle.version>
-        <hibernate-enhance-maven-plugin.version>6.6.9.Final</hibernate-enhance-maven-plugin.version>
-        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+        <commons.net.version>3.12.0</commons.net.version>
+        <commons.configuration>2.12.0</commons.configuration>
+        <swagger.annotation.version>2.2.39</swagger.annotation.version>
+        <bouncycastle.version>1.82</bouncycastle.version>
+        <hibernate-enhance-maven-plugin.version>6.6.33.Final</hibernate-enhance-maven-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -139,8 +139,8 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
                 <version>${commons.configuration}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.czertainly</groupId>
     <artifactId>dependencies</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.1-SNAPSHOT</version>
 
     <name>CZERTAINLY-Dependencies</name>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.5.7</version>
     </parent>
 
     <groupId>com.czertainly</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
         <jaxws-rt.version>4.0.3</jaxws-rt.version>
         <commons.net.version>3.12.0</commons.net.version>
         <commons.configuration>2.12.0</commons.configuration>
-        <swagger.annotation.version>2.2.39</swagger.annotation.version>
+        <swagger.annotation.version>2.2.40</swagger.annotation.version>
         <bouncycastle.version>1.82</bouncycastle.version>
-        <hibernate-enhance-maven-plugin.version>6.6.33.Final</hibernate-enhance-maven-plugin.version>
+        <hibernate-enhance-maven-plugin.version>6.6.34.Final</hibernate-enhance-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     </properties>
 


### PR DESCRIPTION
Update parent org.springframework.boot:spring-boot-starter-parent to v3.5.7
Update project version to 1.3.1-SNAPSHOT
Update plugin org.jacoco:jacoco-maven-plugin to v0.8.14
Update plugin org.apache.maven.plugins:maven-gpg-plugin to v3.2.8
Update plugin org.hibernate.orm.tooling:hibernate-enhance-maven-plugin to v6.6.34.Final
Update dependency org.springframework.data:spring-data-commons to v3.5.5
Update dependency com.fasterxml.jackson.core:jackson-databind to v2.20.0
Update dependency org.wiremock:wiremock to v3.13.1
Update dependency org.apache.logging.log4j:log4j to v2.25.2
Update dependency commons-net:commons-net to v3.12.0
Migrate dependency commons-configuration:commons-configuration (v1.10) to org.apache.commons:commons-configuration2 (v2.12.0)
Update dependency io.swagger.core.v3:swagger-annotations to v2.2.40
Update dependency org.bouncycastle:bcprov-jdk18on to v1.82
Update actions/setup-java action to v5 
Update actions/checkout action to v5