### PR TITLE
Bump dependencies and pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,16 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -35,22 +35,22 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Cache SonarQube packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,9 +15,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -74,7 +74,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_PORTAL_TOKEN_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.13</version>
+        <version>3.5.14</version>
     </parent>
 
     <groupId>com.otilm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,16 +48,16 @@
         <maven.compiler.target>21</maven.compiler.target>
         <maven.jacoco.plugin.version>0.8.14</maven.jacoco.plugin.version>
         <sonar.projectKey>OmniTrustILM-dependencies</sonar.projectKey>
-        <spring.data.common>3.5.10</spring.data.common>
-        <fasterxml.jackson>2.21.2</fasterxml.jackson>
+        <spring.data.common>3.5.11</spring.data.common>
+        <fasterxml.jackson>2.21.3</fasterxml.jackson>
         <wiremock.version>3.13.2</wiremock.version>
         <log4j.version>2.25.2</log4j.version>
         <kxml2.version>2.3.0</kxml2.version>
         <jaxws-rt.version>4.0.4</jaxws-rt.version>
         <commons.net.version>3.13.0</commons.net.version>
-        <commons.configuration>2.13.0</commons.configuration>
-        <swagger.annotation.version>2.2.40</swagger.annotation.version>
-        <bouncycastle.version>1.83</bouncycastle.version>
+        <commons.configuration>2.15.0</commons.configuration>
+        <swagger.annotation.version>2.2.50</swagger.annotation.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
         <hibernate-enhance-maven-plugin.version>6.6.46.Final</hibernate-enhance-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>


### PR DESCRIPTION
## Changes

**Maven dependencies (`pom.xml`):**
- `spring-boot-starter-parent`: 3.5.13 → **3.5.14** (Tomcat CVE-2026-41293)
- `spring-data-commons`: 3.5.10 → **3.5.11**
- `jackson`: 2.21.2 → **2.21.3**
- `commons-configuration2`: 2.13.0 → **2.15.0**
- `swagger-annotations`: 2.2.40 → **2.2.50**
- `bouncycastle`: 1.83 → **1.84** (SECURITY)

**GitHub Actions (pinned to commit SHA):**
- `actions/checkout` → v6.0.2
- `actions/setup-java` → v5.2.0
- `actions/cache` → v5.0.5

Closes #109, #110, #112, #108, #113, #101.