### PR TITLE
Update Spring Boot 3.5.16, Jackson 2.22.0, and batch dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.16</version>
     </parent>
 
     <groupId>com.otilm</groupId>
@@ -46,21 +46,27 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <maven.jacoco.plugin.version>0.8.14</maven.jacoco.plugin.version>
+        <maven.jacoco.plugin.version>0.8.15</maven.jacoco.plugin.version>
         <sonar.projectKey>OmniTrustILM-dependencies</sonar.projectKey>
-        <spring.data.common>3.5.11</spring.data.common>
-        <fasterxml.jackson>2.21.3</fasterxml.jackson>
+        <spring.data.common>3.5.13</spring.data.common>
+        <fasterxml.jackson>2.22.0</fasterxml.jackson>
+        <!-- Realign the whole Jackson train (core + annotations, not just databind/jsr310)
+             ahead of the version managed by spring-boot-dependencies, to keep the modules
+             on one minor. -->
+        <jackson-bom.version>2.22.0</jackson-bom.version>
         <wiremock.version>3.13.2</wiremock.version>
         <log4j.version>2.25.2</log4j.version>
         <kxml2.version>2.3.0</kxml2.version>
-        <jaxws-rt.version>4.0.4</jaxws-rt.version>
+        <jaxws-rt.version>4.0.5</jaxws-rt.version>
         <commons.net.version>3.13.0</commons.net.version>
-        <commons.configuration>2.15.0</commons.configuration>
-        <swagger.annotation.version>2.2.50</swagger.annotation.version>
+        <commons.configuration>2.15.1</commons.configuration>
+        <swagger.annotation.version>2.2.52</swagger.annotation.version>
         <bouncycastle.version>1.84</bouncycastle.version>
-        <hibernate-enhance-maven-plugin.version>6.6.46.Final</hibernate-enhance-maven-plugin.version>
+        <!-- Must match the hibernate-core version Spring Boot manages: the enhance plugin
+             stamps bytecode with its own version and Hibernate rejects a runtime mismatch. -->
+        <hibernate-enhance-maven-plugin.version>${hibernate.version}</hibernate-enhance-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,8 @@
         <maven.compiler.target>21</maven.compiler.target>
         <maven.jacoco.plugin.version>0.8.15</maven.jacoco.plugin.version>
         <sonar.projectKey>OmniTrustILM-dependencies</sonar.projectKey>
-        <spring.data.common>3.5.13</spring.data.common>
-        <fasterxml.jackson>2.22.0</fasterxml.jackson>
-        <!-- Realign the whole Jackson train (core + annotations, not just databind/jsr310)
-             ahead of the version managed by spring-boot-dependencies, to keep the modules
-             on one minor. -->
+        <!-- Overrides the whole Jackson train (spring-boot-dependencies imports jackson-bom
+             via this property); drop once Spring Boot manages Jackson >= 2.22.0. -->
         <jackson-bom.version>2.22.0</jackson-bom.version>
         <wiremock.version>3.13.2</wiremock.version>
         <log4j.version>2.25.2</log4j.version>
@@ -62,8 +59,7 @@
         <commons.configuration>2.15.1</commons.configuration>
         <swagger.annotation.version>2.2.52</swagger.annotation.version>
         <bouncycastle.version>1.84</bouncycastle.version>
-        <!-- Must match the hibernate-core version Spring Boot manages: the enhance plugin
-             stamps bytecode with its own version and Hibernate rejects a runtime mismatch. -->
+        <!-- Track Spring Boot's hibernate-core; a plugin/runtime mismatch breaks enhancement. -->
         <hibernate-enhance-maven-plugin.version>${hibernate.version}</hibernate-enhance-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
@@ -71,13 +67,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!--    SPRING libs additional    -->
-            <dependency>
-                <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-commons</artifactId>
-                <version>${spring.data.common}</version>
-            </dependency>
-
             <!-- DB -->
             <dependency>
                 <groupId>org.postgresql</groupId>
@@ -97,16 +86,6 @@
                 <version>${jakarta-xml-ws.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${fasterxml.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${fasterxml.jackson}</version>
-            </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,9 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.jacoco.plugin.version>0.8.15</maven.jacoco.plugin.version>
-        <sonar.projectKey>OmniTrustILM-dependencies</sonar.projectKey>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.organization>ilm</sonar.organization>
+        <sonar.projectKey>ilm_dependencies</sonar.projectKey>
         <!-- Overrides the whole Jackson train (spring-boot-dependencies imports jackson-bom
              via this property); drop once Spring Boot manages Jackson >= 2.22.0. -->
         <jackson-bom.version>2.22.0</jackson-bom.version>


### PR DESCRIPTION
## Summary

Non-major Renovate dependency batch for the parent BOM, validated end-to-end against the two heaviest consumers (`interfaces`, `core`) before landing, then hardened following a multi-reviewer pass.

## Changes

| Dependency | From | To | Note |
|---|---|---|---|
| spring-boot-starter-parent | 3.5.14 | 3.5.16 | also brings Tomcat 10.1.55 into the managed set |
| Jackson (whole train) | 2.21.3 | 2.22.0 | via `jackson-bom.version` (see below) |
| swagger-annotations | 2.2.50 | 2.2.52 | |
| commons-configuration2 | 2.15.0 | 2.15.1 | |
| jaxws-rt | 4.0.4 | 4.0.5 | |
| jacoco-maven-plugin | 0.8.14 | 0.8.15 | |
| central-publishing-maven-plugin | 0.10.0 | 0.11.0 | |

### Structural changes (beyond raw version bumps)

- **Jackson via a single knob.** `jackson-bom.version` is set to 2.22.0 — Spring Boot imports jackson-bom through this property, so it moves the *entire* train (core, annotations, databind, jsr310, dataformat-*) together, one minor ahead of Spring Boot's managed 2.21.4. The previous per-artifact overrides (`fasterxml.jackson` property + explicit `jackson-databind`/`jsr310` `dependencyManagement` entries) are **removed** — keeping them alongside the BOM property created a two-knob drift risk (a one-sided bump could re-split the train; `core`'s `jackson-dataformat-csv` is governed only by the BOM property).
- **hibernate-enhance-maven-plugin → `${hibernate.version}`.** The enhance plugin must equal the Spring-Boot-managed `hibernate-core` (currently 6.6.53), or core's bytecode enhancement fails at build time with a version mismatch. Tying it to the property makes it auto-track every future Spring Boot bump. (Renovate's independent bump to 6.6.54 would break core — see #107.)
- **`spring-data-commons` override removed.** Spring Boot 3.5.16 manages spring-data-bom 2025.0.13 → spring-data-commons 3.5.13, so the explicit pin is redundant; it now inherits from Spring Boot.

## SonarCloud / CI config

Also aligns this repo's SonarCloud setup with the newer OmniTrustILM Java repos (core, interfaces): adds `sonar.host.url` + `sonar.organization=ilm` and renames `sonar.projectKey` `OmniTrustILM-dependencies` → `ilm_dependencies`. This is a CI-integration change (called out separately from the dependency bumps): it repoints analysis to the `ilm_dependencies` project under the `ilm` org, so the SonarCloud check should be confirmed green on the first run (the target project must exist / auto-provision).

## Validation

Installed as `dependencies:1.4.2-SNAPSHOT` locally and built both consumers against it:

- **interfaces**: `mvn verify` → **395 tests, 0 failures/errors** (incl. polymorphic-serialization + custom deserializer suites — the Jackson 2.22.0 gate).
- **core**: `mvn clean verify` in an isolated worktree with Testcontainers → **3613 tests, 0 failures/errors**. Hibernate enhance ran at 6.6.53 with no mismatch.
- `dependency:tree` on both consumers confirms the whole Jackson train at **2.22.0** and spring-data-commons at **3.5.13** after the structural cleanup (version-neutral).

Also confirmed Spring Boot 3.5.16 manages Tomcat **10.1.55**, so core's temporary `<tomcat.version>` CVE override becomes removable once this ships.

## Supersedes

Close after merge (Renovate will auto-close the folded-in ones on its next run):

- **#123** (Jackson 2.21.4 security) — 2.22.0 includes CVE-2026-54518 / CVE-2026-54516.
- **#107** (hibernate-enhance 6.6.54) — replaced by `${hibernate.version}`; 6.6.54 breaks core.
- Folds in **#117, #121, #120, #125, #116, #118, #119, #126**.

## Out of scope

Major v4 bumps (**#100** Spring Boot 4, **#97** Spring Data 4) — separate migration. Cutting a `dependencies` release and bumping `core`/`interfaces` parents (and deleting core's Tomcat override) are follow-ups, not part of this PR.

