### PR TITLE
Fix jackson-core and postgresql vulnerabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,13 @@ There are no tests or source code to compile in this repository itself. The `ver
 ## Dependency Updates
 
 Automated via Renovate (`renovate.json`). PRs are created automatically when new dependency versions are available.
+
+### Version overrides ahead of the parent
+
+Most versions come from the Spring Boot parent's curated, pre-tested set — that is the value of inheriting the BOM. Occasionally a CVE hits a parent-managed library before any Spring Boot release adopts the fix; then this POM pins the fixed version ahead of the parent. Treat every such override as temporary debt with an expiry date:
+
+- **Override only when forced.** If a published Spring Boot release already carries the fix, bump `spring-boot-starter-parent` instead — one knob, and the whole set stays tested together. Override a single library only when *no* release fixes it yet.
+- **Forward-only.** An override must be `>=` the parent-managed version, never behind it.
+- **Make it Renovate-visible.** A bare `<x.version>` property that only overrides a parent-managed version by name is invisible to Renovate — it has no dependency to map to, so it never gets an update PR. Back each override with an explicit `<dependency>` (or BOM `import`) in `dependencyManagement` that references `${x.version}`.
+- **Document why and when it can go.** Comment each override with the driver (CVE) and the condition to remove it.
+- **Undrift on every parent bump.** When bumping Spring Boot, re-audit every override: if the new parent now manages a version `>=` the override, delete the override and fall back to the parent. The vulnerability scanner will *not* flag a redundant override — it is not a vuln — so this is a manual step, not scanner-driven.

--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,14 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>ilm</sonar.organization>
         <sonar.projectKey>ilm_dependencies</sonar.projectKey>
-        <!-- Overrides the whole Jackson train (spring-boot-dependencies imports jackson-bom
-             via this property); drop once Spring Boot manages Jackson >= 2.22.0. -->
-        <jackson-bom.version>2.22.0</jackson-bom.version>
+        <!-- Jackson train pinned one minor ahead of Spring Boot's managed 2.21.x: consumers
+             are already validated on 2.22.x, so we stay rather than re-test a downgrade.
+             Must remain >= 2.22.1 (GHSA-r7wm-3cxj-wff9). Drop once Spring Boot manages
+             Jackson >= 2.22.1. The jackson-bom import below keeps Renovate tracking it. -->
+        <jackson-bom.version>2.22.1</jackson-bom.version>
+        <!-- Override Spring Boot's managed postgresql 42.7.11 (CVE-2026-54291); no Spring Boot
+             release incl. 4.x ships 42.7.12 yet. Drop once the parent manages >= 42.7.12. -->
+        <postgresql.version>42.7.12</postgresql.version>
         <wiremock.version>3.13.2</wiremock.version>
         <log4j.version>2.25.2</log4j.version>
         <kxml2.version>2.3.0</kxml2.version>
@@ -69,6 +74,16 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Explicit import so Renovate tracks jackson-bom.version; overrides
+                 Spring Boot's managed Jackson (nearest definition wins). -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- DB -->
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
## Summary

Clears two HIGH vulnerabilities flagged by Trivy against the parent BOM (surfaced in core's docker image test build, PR OmniTrustILM/core#1855).

| Library | From | To | Advisory |
|---|---|---|---|
| `com.fasterxml.jackson.core:jackson-core` | 2.22.0 | 2.22.1 | GHSA-r7wm-3cxj-wff9 (async parser `maxNumberLength` bypass) |
| `org.postgresql:postgresql` | 42.7.11 | 42.7.12 | CVE-2026-54291 (scram-client) |

## Why these weren't auto-bumped by Renovate

- **jackson**: `jackson-bom.version` overrode Spring Boot's managed version *by name only* — no dependency in this POM referenced it, so Renovate had no datasource to map and never raised a PR. Fixed by importing `jackson-bom` explicitly in `dependencyManagement`, which makes the property trackable going forward.
- **postgresql**: the version was inherited transitively from `spring-boot-starter-parent`; there was no local property to bump. No Spring Boot release — including 4.x — manages 42.7.12, so a parent bump would not have fixed it. Added an explicit `postgresql.version` override; the existing `org.postgresql:postgresql` entry makes it Renovate-tracked from now on.

## Changes

- `pom.xml`: bump `jackson-bom.version` 2.22.0 → 2.22.1; add `postgresql.version` 42.7.12 override; add explicit `jackson-bom` BOM import. Both override comments now state their driver and exit condition.
- `CLAUDE.md`: new **"Version overrides ahead of the parent"** subsection codifying the override lifecycle (override only when forced, forward-only, keep Renovate-visible, document why + exit, undrift on every parent bump).

## Notes

- `postgresql.version` is a temporary override — drop it once a Spring Boot release manages ≥ 42.7.12.
- Consumers (`core`, `interfaces`) already validated on the Jackson 2.22.x train, so this stays ahead of Spring Boot's 2.21.x rather than downgrading.

## Validation

- `mvn validate` passes; imported `jackson-bom` 2.22.1 resolves.
- `mvn help:evaluate` confirms effective `jackson-bom.version=2.22.1`, `postgresql.version=42.7.12`.

## Follow-up

Cut a `dependencies` SNAPSHOT/release and re-run core PR #1855 CI to confirm Trivy clears both.