### PR TITLE
Pin netty 4.1.136.Final ahead of Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <!-- Override Spring Boot's managed postgresql 42.7.11 (CVE-2026-54291); no Spring Boot
              release incl. 4.x ships 42.7.12 yet. Drop once the parent manages >= 42.7.12. -->
         <postgresql.version>42.7.12</postgresql.version>
-        <!-- Override Spring Boot 3.5.16's managed netty 4.1.135.Final: CVE-2026-59901
+        <!-- Override Spring Boot's managed netty 4.1.135.Final: CVE-2026-59901
              (netty-codec Bzip2 infinite loop), CVE-2026-55831 / CVE-2026-55833 /
              CVE-2026-56745 (netty-codec-http). No Spring Boot release ships
              >= 4.1.136.Final yet. Drop once the parent manages >= 4.1.136.Final.

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
         <!-- Override Spring Boot's managed postgresql 42.7.11 (CVE-2026-54291); no Spring Boot
              release incl. 4.x ships 42.7.12 yet. Drop once the parent manages >= 42.7.12. -->
         <postgresql.version>42.7.12</postgresql.version>
+        <!-- Override Spring Boot 3.5.16's managed netty 4.1.135.Final: CVE-2026-59901
+             (netty-codec Bzip2 infinite loop), CVE-2026-55831 / CVE-2026-55833 /
+             CVE-2026-56745 (netty-codec-http). No Spring Boot release ships
+             >= 4.1.136.Final yet. Drop once the parent manages >= 4.1.136.Final.
+             The netty-bom import below keeps Renovate tracking it. -->
+        <netty.version>4.1.136.Final</netty.version>
         <wiremock.version>3.13.2</wiremock.version>
         <log4j.version>2.25.2</log4j.version>
         <kxml2.version>2.3.0</kxml2.version>
@@ -80,6 +86,16 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Explicit import so Renovate tracks netty.version; overrides
+                 Spring Boot's managed netty-bom (nearest definition wins). -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## What

Override Spring Boot 3.5.16's managed netty `4.1.135.Final` with `4.1.136.Final` via the `netty.version` property, backed by a Renovate-visible `io.netty:netty-bom` import in `dependencyManagement`.

## Why

Trivy's image scan on `core` (PR #1868) fails on four HIGH Netty CVEs in the managed `4.1.135.Final`:

| Library | CVE | Fixed |
|---------|-----|-------|
| netty-codec | CVE-2026-59901 (Bzip2 infinite loop) | 4.1.136.Final |
| netty-codec-http | CVE-2026-55831 | 4.1.136.Final |
| netty-codec-http | CVE-2026-55833 | 4.1.136.Final |
| netty-codec-http | CVE-2026-56745 (SpdyHttpDecoder ref leak) | 4.1.136.Final |

`3.5.16` is the latest Spring Boot release and still pins `4.1.135.Final`, so bumping the parent is not an option yet — this follows the repo's documented "pin ahead of the parent" override pattern (forward-only, Renovate-visible, comment with driver + removal condition).

`4.1.136.Final` is the latest `4.1.x` and fixes all four. The only newer release is `4.2.16.Final` (4.2 train, not validated by Spring Boot 3.5.x), so we stay on 4.1.x.

## Removal condition

Drop the override once `spring-boot-starter-parent` manages netty `>= 4.1.136.Final`.

## Testing

- `mvn -B verify` — BUILD SUCCESS
- `mvn help:evaluate -Dexpression=netty.version -DforceStdout` → `4.1.136.Final`