### PR TITLE
Fix the log4j version property name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,10 @@
              The netty-bom import below keeps Renovate tracking it. -->
         <netty.version>4.1.136.Final</netty.version>
         <wiremock.version>3.13.2</wiremock.version>
-        <log4j.version>2.25.2</log4j.version>
+        <!-- Spring Boot's property is log4j2.version, not log4j.version; the latter matched
+             nothing and left consumers on Spring Boot's managed 2.24.3. The log4j-bom import
+             below applies the version and keeps Renovate tracking it. -->
+        <log4j2.version>2.26.1</log4j2.version>
         <kxml2.version>2.3.0</kxml2.version>
         <jaxws-rt.version>4.0.5</jaxws-rt.version>
         <commons.net.version>3.13.0</commons.net.version>
@@ -96,6 +99,16 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Explicit import so Renovate tracks log4j2.version; overrides
+                 Spring Boot's managed log4j2 artifacts (nearest definition wins). -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j2.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,9 @@
         <netty.version>4.1.136.Final</netty.version>
         <wiremock.version>3.13.2</wiremock.version>
         <!-- Spring Boot's property is log4j2.version, not log4j.version; the latter matched
-             nothing and left consumers on Spring Boot's managed 2.24.3. The log4j-bom import
-             below applies the version and keeps Renovate tracking it. -->
+             nothing and left consumers on Spring Boot's managed 2.24.3. Drop once Spring Boot
+             manages log4j2 >= 2.26.1. The log4j-bom import below applies the version and keeps
+             Renovate tracking it. -->
         <log4j2.version>2.26.1</log4j2.version>
         <kxml2.version>2.3.0</kxml2.version>
         <jaxws-rt.version>4.0.5</jaxws-rt.version>


### PR DESCRIPTION
## Summary

`pom.xml` set `<log4j.version>`, but the property Spring Boot's managed log4j2 artifacts actually read is `<log4j2.version>`. The name matched nothing, so the override never applied and every consuming repository stayed on Spring Boot 3.5.16's managed **2.24.3**.

This was silent. The vulnerability scanner does not flag it, because a property that overrides nothing is not itself a finding, and Renovate never proposed a bump either — a bare `<x.version>` property with no backing dependency has nothing to map to, exactly the failure mode this repository's own CLAUDE.md warns about.

## Evidence

Resolved in `ejbca-ng-connector` against `dependencies:1.4.2-SNAPSHOT` before this change — note the bridge sitting two minors behind the artifacts the consumer pinned by hand:

```
org.apache.logging.log4j:log4j-core:jar:2.26.0     (explicit pin in the consumer)
org.apache.logging.log4j:log4j-api:jar:2.26.0      (explicit pin in the consumer)
org.apache.logging.log4j:log4j-1.2-api:jar:2.26.0  (explicit pin in the consumer)
org.apache.logging.log4j:log4j-to-slf4j:jar:2.24.3 (Spring Boot's value, not 2.25.2)
```

`log4j-to-slf4j` resolving to 2.24.3 rather than the intended 2.25.2 is the proof the property was inert.

## Change

- Rename `log4j.version` → `log4j2.version` and raise it to 2.26.1, the current stable 2.x release.
- Back it with a `log4j-bom` import in `dependencyManagement`, matching how `jackson-bom` and `netty-bom` are already handled here. The import applies the version across the whole log4j2 artifact set rather than one artifact at a time, and restores Renovate tracking.

## Verification

Resolved in `ejbca-ng-connector` against this branch, with every local log4j pin removed from the consumer:

```
org.apache.logging.log4j:log4j-core:jar:2.26.1
org.apache.logging.log4j:log4j-api:jar:2.26.1
org.apache.logging.log4j:log4j-1.2-api:jar:2.26.1
org.apache.logging.log4j:log4j-to-slf4j:jar:2.26.1
```

The consumer's build passes with no log4j configuration of its own.

## Impact on consumers

Every repository inheriting this parent moves from log4j2 2.24.3 to 2.26.1 once the snapshot republishes. OmniTrustILM/ejbca-ng-connector#137 depends on this and should merge after it.