### PR TITLE
Add the Java formatting foundation: Spotless and Checkstyle gates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,105 @@
+# EditorConfig — IDE-level enforcement of line endings, indentation and the full
+# Java code style. https://editorconfig.org  (IntelliJ has built-in support; no
+# plugin required, and it takes precedence over the IDE's own code style scheme.)
+# This is the IDE's first line of defence; Spotless (mvn verify) is the authoritative gate.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = space
+indent_size = 4
+continuation_indent_size = 8
+max_line_length = 120
+
+# Never auto-wrap while typing; Spotless owns final wrapping.
+ij_wrap_on_typing = false
+
+# Imports. Never collapse to a wildcard (Checkstyle AvoidStarImport forbids it and
+# Spotless cannot expand one back). Layout is IntelliJ's default and mirrors
+# eclipse.importorder (0= / 1=\#): one alphabetical block, blank line, static last.
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_imports_layout = *,|,$*
+
+# Javadoc. Eclipse puts a single space before a tag description and never pads to
+# align, nor adds <p> to empty lines.
+ij_java_doc_align_param_comments = false
+ij_java_doc_align_exception_comments = false
+ij_java_doc_add_p_tag_on_empty_lines = false
+
+# Blank lines. Eclipse has ONE knob for this (number_of_empty_lines_to_preserve=1);
+# IntelliJ splits it into three, and the two added below default to 2 — omit them
+# and a second blank line between members survives the IDE only for Spotless to
+# collapse it, which is exactly the round-trip drift this file exists to prevent.
+# The key is ..._before_rbrace, NOT ..._before_right_brace: a misspelled ij_*
+# property is silently ignored, so a typo here fails open and undetected.
+ij_java_keep_blank_lines_in_code = 1
+ij_java_keep_blank_lines_in_declarations = 1
+ij_java_keep_blank_lines_before_rbrace = 1
+ij_java_blank_lines_after_class_header = 0
+ij_java_blank_lines_around_method = 1
+ij_java_blank_lines_around_field = 0
+
+# Eclipse always breaks a controlled statement onto its own line and never
+# collapses a simple block, method, lambda or class.
+ij_java_keep_control_statement_in_one_line = false
+ij_java_keep_simple_methods_in_one_line = false
+ij_java_keep_simple_lambdas_in_one_line = false
+ij_java_keep_simple_blocks_in_one_line = false
+ij_java_keep_simple_classes_in_one_line = false
+
+# Wrap per construct only when the line exceeds the margin ("normal" = wrap if
+# long). Do NOT set ij_java_wrap_long_lines = true: it force-breaks long
+# annotations and string literals that Eclipse leaves intact.
+ij_java_wrap_long_lines = false
+ij_java_method_parameters_wrap = normal
+ij_java_call_parameters_wrap = normal
+ij_java_throws_list_wrap = normal
+ij_java_throws_keyword_wrap = normal
+ij_java_binary_operation_wrap = normal
+ij_java_ternary_operation_wrap = normal
+ij_java_assignment_wrap = normal
+ij_java_array_initializer_wrap = normal
+ij_java_extends_list_wrap = normal
+# One call per line, but only for a chain that does not fit. Mirrors Eclipse's
+# alignment_for_selector_in_method_invocation=48.
+ij_java_method_call_chain_wrap = on_every_item
+
+# Eclipse indents every continuation by a flat 8 spaces; IntelliJ aligns to the
+# opening delimiter instead. Continuation alignment is the single largest source of
+# IDE/build drift, so it is off everywhere below.
+ij_java_align_multiline_parameters = false
+ij_java_align_multiline_parameters_in_calls = false
+ij_java_align_multiline_method_parentheses = false
+ij_java_align_multiline_resources = false
+ij_java_align_multiline_for = false
+ij_java_align_multiline_binary_operation = false
+ij_java_align_multiline_ternary_operation = false
+ij_java_align_multiline_throws_list = false
+ij_java_align_throws_keyword = false
+ij_java_align_multiline_parenthesized_expression = false
+ij_java_align_multiline_array_initializer_expression = false
+ij_java_align_multiline_chained_methods = false
+ij_java_align_multiline_records = false
+
+[*.{xml,yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.{sh,cmd,bat}]
+indent_style = space
+indent_size = 4
+
+# Batch files are Windows-only and need CRLF, which is what .gitattributes checks
+# them out as. Without this the [*] default above claims LF and the two layers
+# assert opposite things about the same files.
+[*.{cmd,bat}]
+end_of_line = crlf
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Git-level line-ending normalization (last-resort CRLF defence; the IDE .editorconfig
+# is the first layer). Ensures Java and other text sources are stored and checked out
+# with LF regardless of the developer's OS or core.autocrlf setting.
+* text=auto eol=lf
+
+*.java   text eol=lf
+*.xml    text eol=lf
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.json   text eol=lf
+*.sh     text eol=lf
+*.properties text eol=lf
+
+# Windows-only scripts keep CRLF.
+*.cmd    text eol=crlf
+*.bat    text eol=crlf
+
+# Binaries: never normalize.
+*.jar    binary
+*.png    binary
+*.jpg    binary
+*.gif    binary
+*.p12    binary
+*.jks    binary

--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -6,11 +6,13 @@ on:
       - 'scripts/pre-commit.sh'
       - 'scripts/test-pre-commit.sh'
       - '.github/workflows/hook-tests.yml'
+      - 'pom.xml'
   pull_request:
     paths:
       - 'scripts/pre-commit.sh'
       - 'scripts/test-pre-commit.sh'
       - '.github/workflows/hook-tests.yml'
+      - 'pom.xml'
   workflow_dispatch:
 
 permissions:
@@ -25,9 +27,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: '21'
@@ -74,3 +76,59 @@ jobs:
         run: |
           /bin/bash --version | head -1
           TEST_BASH=/bin/bash /bin/bash scripts/test-pre-commit.sh
+
+  worktree-install:
+    name: linked worktree - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # git-build-hook installs into the git dir of the CURRENT worktree, which for a linked
+      # worktree is .git/worktrees/NAME/ -- a directory Git never runs hooks from. The parent
+      # POM mirrors the hook into the common hooks dir; this proves it, and proves Git then
+      # actually executes the mirrored file.
+      - name: Hook reaches the directory Git runs hooks from
+        shell: bash
+        run: |
+          set -euo pipefail
+          wt="$RUNNER_TEMP/linked-worktree"
+          git worktree add --detach "$wt" HEAD
+          cd "$wt"
+
+          # Start from nothing installed, so a pass cannot be inherited from the main tree.
+          rm -f "$(git rev-parse --git-path hooks)/pre-commit"
+          mvn --batch-mode --non-recursive initialize
+
+          live="$(git rev-parse --git-path hooks)/pre-commit"
+          if [ ! -f "$live" ]; then
+            echo "::error::no pre-commit hook at $live - Git would never run it"
+            exit 1
+          fi
+
+          # Windows has no executable bit and its trace paths use backslashes, so both of the
+          # remaining checks are Unix-only. The mirroring itself is platform-independent.
+          if [ "$RUNNER_OS" != "Windows" ]; then
+            if [ ! -x "$live" ]; then
+              echo "::error::$live is not executable; Git skips non-executable hooks"
+              exit 1
+            fi
+            # Decisive: make Git run a commit and confirm it launched that exact file.
+            GIT_TRACE=1 git -c user.name=ci -c user.email=ci@example.com \
+              commit --allow-empty -m 'hook probe' 2>trace.log
+            if ! grep -qF "start_command: $live" trace.log; then
+              echo "::error::Git did not execute $live"
+              cat trace.log
+              exit 1
+            fi
+          fi
+          echo "hook is live at $live"

--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -1,0 +1,76 @@
+name: pre-commit hook tests
+
+on:
+  push:
+    paths:
+      - 'scripts/pre-commit.sh'
+      - 'scripts/test-pre-commit.sh'
+      - '.github/workflows/hook-tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/pre-commit.sh'
+      - 'scripts/test-pre-commit.sh'
+      - '.github/workflows/hook-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  harness:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # A CRLF shebang makes the hook unrunnable. .gitattributes pins these to
+      # LF; this proves the checkout honoured it, on Windows in particular.
+      - name: Reject CRLF line endings
+        shell: bash
+        run: |
+          status=0
+          for f in scripts/pre-commit.sh scripts/test-pre-commit.sh; do
+            if awk '/\r$/ { found = 1 } END { exit !found }' "$f"; then
+              echo "::error file=$f::has CRLF line endings"
+              status=1
+            fi
+          done
+          exit $status
+
+      - name: Report the environment
+        shell: bash
+        run: |
+          echo "uname -s : $(uname -s)"
+          echo "bash     : $BASH_VERSION"
+          echo "git      : $(git --version)"
+          echo "awk      : $(command -v awk)"
+          echo "cygpath  : $(command -v cygpath || echo 'n/a')"
+
+      - name: Harness (stubbed Maven)
+        shell: bash
+        run: bash scripts/test-pre-commit.sh
+
+      - name: Harness against the real Spotless plugin
+        shell: bash
+        run: |
+          if command -v mvn >/dev/null 2>&1; then
+            E2E=1 bash scripts/test-pre-commit.sh
+          else
+            echo "::warning::no mvn on PATH; skipped the real-Spotless case"
+          fi
+
+      - name: Harness under macOS system bash 3.2
+        if: runner.os == 'macOS'
+        run: |
+          /bin/bash --version | head -1
+          TEST_BASH=/bin/bash /bin/bash scripts/test-pre-commit.sh

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           set -o pipefail
           mvn --batch-mode -Pcentral -Dgpg.passphrase="$GPG_PASSPHRASE" \
-              source:jar javadoc:jar -f pom.xml deploy | tee mvn.log
+              -f pom.xml deploy | tee mvn.log
 
           # For releases, surface the deploymentId so it's easy to find in the Portal UI.
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
@@ -83,7 +83,7 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: Publish to GitHub Packages
-        run: mvn --batch-mode -Pgithub source:jar javadoc:jar -f pom.xml deploy
+        run: mvn --batch-mode -Pgithub -f pom.xml deploy
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ target/
 .sts4-cache
 
 ### IntelliJ IDEA ###
-.idea
+.idea/
 *.iws
 *.iml
 *.ipr

--- a/.otilm-aggregator
+++ b/.otilm-aggregator
@@ -1,0 +1,16 @@
+This file exists solely to be detected by Maven profile activation in pom.xml.
+It marks "this checkout is the dependencies aggregator itself", as opposed to a
+child repo that inherits from it. Two profiles key off it:
+
+  skip-format-gates-on-aggregator  (<exists>)  - unbind Spotless/Checkstyle here, because build-tools is built by
+                                                 this same reactor (bootstrap cycle)
+  hooks-from-build-tools-jar       (<missing>) - only children pull the pre-commit hook off the plugin classpath
+
+An earlier version keyed off <exists>build-tools/pom.xml</exists>, which is not
+unique: any child repo that happens to contain a module directory named
+build-tools would have silently had its formatting gate disabled. A marker with
+this name cannot collide by accident.
+
+Do not delete or rename this file without updating pom.xml. Maven's FileProfileActivator only ever evaluates
+ONE path per profile - given both <exists> and <missing> in the same <file> element it uses <exists> and silently
+ignores <missing> - so each activation condition above must stay in its own profile.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,11 @@ its jar; both plugins read them off their **plugin** classpath, which is why thi
 - **`scripts/pre-commit.sh`** formats staged Java files before commit. It ships in the
   build-tools jar, so a child gets it installed automatically at `initialize`; `scripts/test-pre-commit.sh`
   is its test harness and runs on all three platforms in `hook-tests.yml`.
+  - The install **replaces** any existing `.git/hooks/pre-commit` on every build — no chaining,
+    no prompt. That is intended; `-Dgitbuildhook.install.skip=true` is the opt-out.
+  - In a **linked worktree**, an antrun step in the `install-git-hooks` profile mirrors the hook
+    into the common hooks dir, where Git runs it from. The `worktree-install` job in
+    `hook-tests.yml` guards this.
 
 **Keep `checkstyle.xml` to those four rules.** It exists to close Spotless's blind spots, not to
 become a second linter — every rule added there is a rule 20+ repos must satisfy at once, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a **Maven parent POM** (no application source code) that serves as the centralized dependency management BOM for the ILM platform. Java/Spring Boot modules and connectors inherit from this POM to get standardized, pre-vetted library versions.
+This is a **Maven parent POM** (no application source code) that serves as the centralized dependency management BOM for the ILM platform. Java/Spring Boot modules and connectors inherit from this POM to get standardized, pre-vetted library versions. It also owns the platform's Java **formatting and lint gates** (see below), which children likewise inherit.
 
 - **Group ID**: `com.otilm`
 - **Artifact ID**: `dependencies`
@@ -25,7 +25,15 @@ mvn help:effective-pom
 mvn help:evaluate -Dexpression=project.version -q -DforceStdout
 ```
 
-There are no tests or source code to compile in this repository itself. The `verify` phase validates the POM structure and runs JaCoCo (inherited by child projects).
+```bash
+# Run once after cloning. Both gates take com.otilm:build-tools on their PLUGIN classpath, and a
+# standalone goal invocation (unlike a lifecycle build) does not package it first, so `mvn
+# spotless:apply` — which is what the pre-commit hook runs — cannot construct its plugin realm
+# until build-tools exists in ~/.m2.
+mvn -B install
+```
+
+The only Java in this repository is the `formatter-selftest` fixture set; the aggregator itself has nothing to compile. The `verify` phase validates the POM structure, smoke-tests the Checkstyle ruleset and the formatter profile, and runs JaCoCo (inherited by child projects).
 
 ## Versioning Rules
 
@@ -45,6 +53,45 @@ There are no tests or source code to compile in this repository itself. The `ver
 - **JaCoCo** runs coverage during the `package` phase
 - **maven-jar-plugin** disables Maven descriptor in archives (`addMavenDescriptor: false`)
 - **maven-compiler-plugin** enables `parameters=true` for reflection support
+
+## Formatting and lint gates (inherited by child projects)
+
+Two plugins, both bound to `verify`, so a child's existing CI gates on them with no workflow
+changes. Their rules live in the `com.otilm:build-tools` module of this reactor and ship inside
+its jar; both plugins read them off their **plugin** classpath, which is why this POM declares
+`<pluginRepositories>`.
+
+- **Spotless** (`spotless:check`) — formats `src/{main,test}/java` from
+  `otilm/eclipse-formatter.xml` (Eclipse JDT engine) and `otilm/eclipse.importorder`. `mvn
+  spotless:apply` fixes every violation mechanically.
+- **Checkstyle** (`checkstyle:check`) — `otilm/checkstyle.xml`, exactly four rules that Spotless
+  *cannot* enforce: `AvoidStarImport`, `NeedBraces`, `UnusedImports`, `RedundantImport`. These
+  need hand-fixing; `spotless:apply` will not do it.
+- **`.editorconfig`** is the IDE-side mirror of the Eclipse profile and must be kept in parity
+  with it — the procedure is in the header of `otilm/eclipse-formatter.xml`.
+- **`scripts/pre-commit.sh`** formats staged Java files before commit. It ships in the
+  build-tools jar, so a child gets it installed automatically at `initialize`; `scripts/test-pre-commit.sh`
+  is its test harness and runs on all three platforms in `hook-tests.yml`.
+
+**Keep `checkstyle.xml` to those four rules.** It exists to close Spotless's blind spots, not to
+become a second linter — every rule added there is a rule 20+ repos must satisfy at once, and
+unlike a formatting rule it cannot be fixed by running a command.
+
+Escape hatches, in order of bluntness: `-Dspotless.skip=true`, `-Dcheckstyle.skip=true`,
+`-Dgitbuildhook.install.skip=true`, and `git commit --no-verify` for the hook.
+
+### Rolling the gates out to a child repo
+
+Order matters — bumping the parent first leaves the repo red until the reformat lands:
+
+1. `mvn spotless:apply`, then hand-fix what Checkstyle reports.
+2. Commit that as a single mechanical reformat commit, touching nothing else.
+3. Record its SHA in a `.git-blame-ignore-revs` at the repo root; the `blame-ignore-revs`
+   profile then wires local `git blame` to skip it automatically (GitHub's web UI does this on
+   its own).
+4. Copy in `.editorconfig` and `.gitattributes`. The parent POM cannot deliver these — they must
+   exist in the repo before the IDE or checkout honours them.
+5. Only then bump `<parent>` to the version carrying the gates.
 
 ## Dependency Updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ The only Java in this repository is the `formatter-selftest` fixture set; the ag
 ## Maven Profiles
 
 - **`central`**: Publishes to Maven Central Portal with GPG signing. Requires `MAVEN_GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE`, and Central Portal credentials. After deployment, releases sit in VALIDATED state until manually published in the Portal UI.
+  - **Any new `packaging=jar` module must attach both a `-sources.jar` and a `-javadoc.jar`.** Central rejects the deployment if either is missing, and it does so *after* the release tag is already pushed.
 - **`github`**: Publishes to GitHub Packages.
 
 ## Key Plugin Configuration (inherited by child projects)

--- a/README.md
+++ b/README.md
@@ -19,3 +19,39 @@ For more information, see [pom.xml](./pom.xml).
     <version>${version}</version>
 </parent>
 ```
+
+## Java formatting
+
+**Inheriting this parent also turns on two build gates that fail on badly formatted Java, so read this before bumping the version.**
+
+Both gates run in the `verify` phase. Your existing CI already reaches that phase, so no workflow change is needed — and nothing is skipped just because you did not ask for it.
+
+| Gate       | What it checks                                                                                   | How to fix a failure                                |
+|------------|--------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| Spotless   | The whole canonical style: indentation, wrapping, import order                                   | `mvn spotless:apply` fixes every violation          |
+| Checkstyle | Four things Spotless cannot: `AvoidStarImport`, `NeedBraces`, `UnusedImports`, `RedundantImport` | Manually or with IDE — no command does this for you |
+
+The rules live in the `com.otilm:build-tools` artifact, so you do not copy them into your repo. A `pre-commit` hook that formats your staged Java files is installed automatically on your first build; it ships in the same artifact.
+
+### Rolling it out to an existing repo
+
+**Do the reformat first and the version bump last.** In the other order your build is red in between.
+
+1. Bump the parent locally, without committing it.
+2. Run `mvn spotless:apply`.
+3. Run `mvn verify` and hand-fix what Checkstyle reports. Wildcard imports are the common one.
+4. Commit the result as a single mechanical reformat commit. Change nothing else in it.
+5. Create a `.git-blame-ignore-revs` at the repo root containing that commit's SHA. `git blame` then skips it, locally and in the GitHub UI.
+6. Copy `.editorconfig` and `.gitattributes` from this repo. The parent POM cannot deliver these — your IDE only honours files that exist in your own repo.
+7. Commit the parent bump.
+
+### When you need to opt out
+
+| Situation                           | Escape hatch                       |
+|-------------------------------------|------------------------------------|
+| One build, formatting not the point | `-Dspotless.skip=true`             |
+| One build, lint not the point       | `-Dcheckstyle.skip=true`           |
+| You do not want the hook installed  | `-Dgitbuildhook.install.skip=true` |
+| One commit, hook in the way         | `git commit --no-verify`           |
+
+None of these change CI, which stays the authoritative gate.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Both gates run in the `verify` phase. Your existing CI already reaches that phas
 
 The rules live in the `com.otilm:build-tools` artifact, so you do not copy them into your repo. A `pre-commit` hook that formats your staged Java files is installed automatically on your first build; it ships in the same artifact.
 
+### What the hook install does to your repo
+
+**Every Maven build writes `.git/hooks/pre-commit`, replacing whatever is already there.** The content is the same on every build, so this is a no-op unless you keep a `pre-commit` hook of your own — and if you do, it will be overwritten without a prompt. Nothing chains it. Use `-Dgitbuildhook.install.skip=true` if you need your own hook to survive.
+
+Hooks are not tracked by Git, so this only ever affects your machine.
+
+Linked worktrees work: Maven mirrors the hook into the shared hooks directory that Git actually runs hooks from, because installing it into the per-worktree directory would leave it silently unused.
+
 ### Rolling it out to an existing repo
 
 **Do the reformat first and the version bump last.** In the other order your build is red in between.

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -78,7 +78,24 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Central requires a -javadoc.jar for every published artifact. This module is resources-only. -->
+            <!-- Central requires BOTH a -javadoc.jar and a -sources.jar for every published jar artifact,
+                 and rejects the deployment after the tag is already pushed if either is missing. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <forceCreation>true</forceCreation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.otilm</groupId>
+        <artifactId>dependencies</artifactId>
+        <version>1.4.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>build-tools</artifactId>
+    <packaging>jar</packaging>
+
+    <name>build-tools</name>
+    <description>ILM - shared build configuration: canonical Java formatter profile and import order, consumed by Spotless</description>
+    <url>https://github.com/OmniTrustILM/dependencies</url>
+
+    <properties>
+        <!-- Keeps a standalone `mvn spotless:apply` working in this repo. A lifecycle build is
+             fine unaided — package runs before verify, so Spotless resolves build-tools straight
+             out of the reactor — but a direct goal invocation builds no jar first, so the plugin realm
+             cannot be constructed and Maven fails before any skip flag is read. That direct invocation is
+             exactly what scripts/pre-commit.sh runs. Note this property alone would NOT be enough for the
+             lifecycle case; the unbinding below is what does that work. -->
+        <spotless.skip>true</spotless.skip>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- Ship the pre-commit hook in the jar so child repos install it off the plugin classpath
+                 (see the hooks-from-build-tools-jar profile in the parent). -->
+            <resource>
+                <directory>${project.basedir}/../scripts</directory>
+                <targetPath>scripts</targetPath>
+                <includes>
+                    <include>pre-commit.sh</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <!-- The parent's build-tools.version property has to be a literal (inherited property values re-interpolate
+                 in the consuming project), so it duplicates the reactor version. Assert here that the two agree. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-tools-version-lockstep</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireProperty>
+                                    <property>build-tools.version</property>
+                                    <regex>\Q${project.version}\E</regex>
+                                    <regexMessage>build-tools.version is ${build-tools.version} but this reactor builds ${project.version} — bump build-tools.version in the parent pom.xml to match &lt;version&gt;.</regexMessage>
+                                </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Unbind spotless:check here: this module has no Java sources for it to look at. -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>spotless-check</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Central requires a -javadoc.jar for every published artifact. This module is resources-only. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>placeholder-javadoc-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.build.directory}/placeholder-javadoc</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- ...and the directory it packs, so the jar is created on a clean checkout. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-placeholder-javadoc-dir</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/placeholder-javadoc"/>
+                                <echo file="${project.build.directory}/placeholder-javadoc/README.txt">This
+artifact ships build configuration resources only (formatter profile, import order,
+Checkstyle rules) and has no Java sources to document. This placeholder exists
+because Maven Central requires a -javadoc.jar for every published artifact.</echo>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/build-tools/src/main/resources/otilm/checkstyle.xml
+++ b/build-tools/src/main/resources/otilm/checkstyle.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+  OmniTrust ILM lint gate. Complements Spotless: Spotless normalises whitespace/wrapping and orders
+  imports, but it cannot forbid wildcard imports (no type info) or require braces. These rules close
+  that gap and run in the same `verify` phase as spotless:check.
+
+  Four rules, and it stays four. Every rule here is one that 20+ repos must satisfy at once, and
+  unlike a formatting rule none of them can be fixed by running a command — see CLAUDE.md.
+
+  Every <property> below restates the Checkstyle 13.6.0 default; each was verified by diffing the
+  reported violations against a bare module declaration. They are spelled out so an upstream default
+  change cannot quietly loosen the gate on a checkstyle.version bump, not because they alter
+  anything today.
+-->
+<module name="Checker">
+    <property name="severity" value="error"/>
+    <property name="fileExtensions" value="java"/>
+
+    <module name="TreeWalker">
+        <!-- Spotless deletes unused imports but never expands a wildcard into explicit single-type imports.
+             Do it here. -->
+        <module name="AvoidStarImport">
+            <property name="allowClassImports" value="false"/>
+            <property name="allowStaticMemberImports" value="false"/>
+        </module>
+
+        <!-- if/else/for/while/do only. A switch case or default body and a lambda body may still
+             omit braces — neither is in the token set, and both are idiomatic without. -->
+        <module name="NeedBraces">
+            <property name="tokens"
+                      value="LITERAL_DO,LITERAL_ELSE,LITERAL_FOR,LITERAL_IF,LITERAL_WHILE"/>
+        </module>
+
+        <!-- Keep imports which are used only in JavaDoc {@link}. -->
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+
+        <!-- Catches what UnusedImports cannot: an import that IS used but should never have been
+             written — a duplicate, or a type from java.lang or from this file's own package. -->
+        <module name="RedundantImport"/>
+    </module>
+</module>

--- a/build-tools/src/main/resources/otilm/checkstyle.xml
+++ b/build-tools/src/main/resources/otilm/checkstyle.xml
@@ -9,7 +9,7 @@
   that gap and run in the same `verify` phase as spotless:check.
 
   Four rules, and it stays four. Every rule here is one that 20+ repos must satisfy at once, and
-  unlike a formatting rule none of them can be fixed by running a command — see CLAUDE.md.
+  unlike a formatting rule none of them can be fixed by running a command.
 
   Every <property> below restates the Checkstyle 13.6.0 default; each was verified by diffing the
   reported violations against a bare module declaration. They are spelled out so an upstream default

--- a/build-tools/src/main/resources/otilm/eclipse-formatter.xml
+++ b/build-tools/src/main/resources/otilm/eclipse-formatter.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="23">
+  <!--
+    OmniTrust ILM canonical Java formatter profile.
+
+    This file is the source of truth for `mvn spotless:apply`, and for the build it always wins.
+    Its IntelliJ-side mirror is the ij_* block of [*.java] in each repo's .editorconfig.
+    The two must stay in parity. Keeping them there is what the check below is for.
+
+    Targets Java 21 (compilerCompliance=21), matching maven.compiler.source=21 in the parent POM.
+
+    An edit here is guarded, but only partly. The formatter-selftest module holds canonical
+    fixtures, so an edit that changes how anything is formatted fails its spotless:check before it
+    can reach a child repo. Two kinds of edit still slip through: one whose Eclipse default happens
+    to equal the value it replaces, and one that only governs how NON-canonical input gets
+    normalized. The mutation table in formatter-selftest/pom.xml records which is which.
+
+    == Round-trip parity check ==
+
+    Run it after editing this file. Run it after bumping spotless-maven-plugin. Run it after
+    bumping spotless.eclipse-jdt.version, which is pinned separately in the parent POM.
+
+      1. Quit IntelliJ. Its CLI shares the config lock.
+      2. Reformat sources that are already Spotless-clean, using IntelliJ's own engine. On macOS:
+           "<IntelliJ IDEA.app>/Contents/bin/format.sh" -r -m '*.java' -allowDefaults <repo>
+         No code-style scheme is passed. IntelliJ reads .editorconfig straight from the repo,
+         exactly as the IDE does.
+      3. Diff the result against HEAD.
+
+    A passing check means no changes, except the known continuation-indent residual.
+    That residual shows up in roughly a fifth of real files. It is confined to nested constructs:
+    annotation arrays, lambdas, deeply nested call arguments, record headers. Those are where the
+    two engines' wrap algorithms fundamentally differ, so it cannot be closed from the IntelliJ
+    side. The pre-commit hook normalizes it before commit, which is why it never reaches CI.
+
+    Anything beyond that residual is drift. Hand-tune the ij_* properties, then repeat from step 1.
+    Do not land the change until the check holds.
+
+    Editing the ij_* side: take property names from
+    Settings | Editor | Code Style | gear | Export | EditorConfig File.
+    That export is IntelliJ's own vocabulary. A misspelled ij_* property is silently ignored rather
+    than rejected, so a typo there fails open.
+
+    Checking a single file by hand: Ctrl+Alt+L in IntelliJ, then `mvn spotless:check`.
+  -->
+  <profile kind="CodeFormatterProfile" name="OmniTrust" version="23">
+    <setting id="org.eclipse.jdt.core.compiler.source" value="21"/>
+    <setting id="org.eclipse.jdt.core.compiler.compliance" value="21"/>
+    <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="21"/>
+
+    <!-- Indentation: 4 spaces, no tabs; continuation = 2 * indent = 8 spaces -->
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+    <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+
+    <!-- Line wrapping -->
+    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+    <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+
+    <!-- Brace positions: K&R / end-of-line -->
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_constructor" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+
+    <!-- Blank lines -->
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+
+    <!-- Annotations: one per line -->
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+
+    <!-- Control statements: keep else/catch/finally on the same line as the closing brace -->
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_control_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_if_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+
+    <!-- Fluent/builder chains: chop to one call per line when the chain overflows 120 cols
+         (M_ONE_PER_LINE_SPLIT, no force bit). Short chains that already fit stay on one line.
+         Byte-identical to IntelliJ METHOD_CALL_CHAIN_WRAP=5 ("chop down if long"). -->
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="48"/>
+
+    <!-- Common spacing -->
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+    <!-- Eclipse JDT defaults to a space before the colon in switch case labels ("case X :").
+         Override to the conventional, IntelliJ-matching "case X:". -->
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+
+    <!-- Comments -->
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+
+    <!-- Misc -->
+    <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+    <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+  </profile>
+</profiles>

--- a/build-tools/src/main/resources/otilm/eclipse.importorder
+++ b/build-tools/src/main/resources/otilm/eclipse.importorder
@@ -1,0 +1,7 @@
+#Organize Import Order
+# Mirrors IntelliJ IDEA's DEFAULT import layout so stock "Optimize Imports" agrees with the build:
+#   (empty)   -> all non-static imports, sorted alphabetically by FQN as a single group
+#                (com.*, jakarta.*, java.*, javax.*, org.* ... no java/javax/jakarta sub-grouping)
+#   \#        -> all static imports, placed last (Spotless/Eclipse inserts one blank line before them)
+0=
+1=\#

--- a/formatter-selftest/pom.xml
+++ b/formatter-selftest/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.otilm</groupId>
+        <artifactId>dependencies</artifactId>
+        <version>1.4.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>formatter-selftest</artifactId>
+    <packaging>jar</packaging>
+
+    <name>formatter-selftest</name>
+    <description>ILM - regression fixtures for the canonical Java formatter profile; not published</description>
+
+    <!-- Why this module exists: nothing else in this repo ever runs the formatter. Spotless is
+         unbound in the aggregator (bootstrap cycle) and in build-tools (no sources), so
+         otilm/eclipse-formatter.xml was shipped to every child repo without a single engine ever
+         having parsed it. Eclipse JDT SILENTLY IGNORES an unknown or misspelled <setting id>, so a
+         typo does not fail anything here — it just quietly changes how 20+ repos get formatted, and
+         the first symptom is a child's whole source tree turning up dirty.
+         The fixtures under src/main/java are canonical output — they are what `spotless:apply`
+         produces, never hand-edited. The ordinary inherited spotless:check then asserts that the
+         profile still produces exactly them, so a change that alters formatting fails HERE, before
+         it can be published. Mutation-tested; the results define what this module does and does not
+         cover:
+           tabulation.char space -> tab .......................... caught
+           lineSplit 120 -> 100 ................................. caught
+           tabulation.char id misspelled ........................ caught (default is tab)
+           tabulation.size id misspelled ........................ not caught (default is also 4)
+           lineSplit removed entirely ........................... not caught (default is also 120)
+           number_of_empty_lines_to_preserve 1 -> 3 ............. not caught
+         The two "default is also" rows are not gaps: an ignored setting whose engine default equals
+         our value changes nothing today, and the check starts failing the moment an Eclipse JDT bump
+         moves that default — which is exactly when it begins to matter.
+         The last row IS a real limit. A setting that only governs how NON-canonical input is
+         normalised (collapsing blank runs, rewrapping over-long lines) cannot be exercised by a
+         fixture that is already canonical. Covering those needs a second, deliberately misformatted
+         fixture set plus an expected-output comparison, which this module does not have.
+         The module depends on nothing and has no unit tests: the gate is the assertion. Ordered
+         after build-tools in the parent's <modules> so Spotless resolves the rules from the reactor
+         rather than from a repository. -->
+
+    <properties>
+        <!-- Fixtures are not a product. maven.install.skip keeps them out of ~/.m2;
+             maven.deploy.skip covers the github profile, which deploys via maven-deploy-plugin.
+             The central profile does NOT honour either flag — central-publishing-maven-plugin
+             never reads them (checked against the 0.11.0 bytecode) — so the parent's central
+             profile excludes this artifactId explicitly. Both halves are needed. -->
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+</project>

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Imports.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Imports.java
@@ -1,0 +1,38 @@
+package com.otilm.selftest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Comparator.comparing;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Fixture for otilm/eclipse.importorder: one alphabetical block, a blank line, then statics last.
+ *
+ * <p>
+ * Every import below is used. That is load-bearing: Spotless runs removeUnusedImports, so an unused one would be
+ * deleted and this file would fail its own check for the wrong reason. Adding an import here means using it.
+ */
+public final class Imports {
+
+    private Imports() {
+    }
+
+    static Map<String, Long> timings(List<String> labels, Set<String> excluded) {
+        requireNonNull(labels, "labels");
+        Map<String, Long> result = new TreeMap<>();
+        List<String> kept = labels
+                .stream()
+                .filter(label -> !excluded.contains(label))
+                .sorted(comparing(String::length))
+                .collect(toList());
+        for (String label : kept) {
+            result.put(label, TimeUnit.SECONDS.toMillis(label.length()));
+        }
+        return result;
+    }
+}

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Members.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Members.java
@@ -1,0 +1,85 @@
+package com.otilm.selftest;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fixture for blank-line handling, brace placement and the member layout settings.
+ *
+ * <p>
+ * Eclipse collapses runs of blank lines to one (number_of_empty_lines_to_preserve=1) and IntelliJ splits that single
+ * knob into three .editorconfig properties. The single blank lines below are what both engines must converge on, so
+ * this file fails if either side's setting is dropped.
+ */
+public class Members {
+
+    /** Nested enum: exercises constant layout and the blank line after a class header. */
+    public enum State {
+
+        PENDING, ACTIVE, CLOSED;
+
+        boolean terminal() {
+            return this == CLOSED;
+        }
+    }
+
+    /** Record header wrapping is one of the known IntelliJ/Eclipse divergences. */
+    public record Window(String label, Duration length, State state, int priority, boolean sticky) {
+
+        public Window {
+            if (length.isNegative()) {
+                throw new IllegalArgumentException("length must not be negative");
+            }
+        }
+    }
+
+    private static final int MAX = 16;
+
+    private final List<Window> windows = new ArrayList<>();
+    private State state = State.PENDING;
+
+    public Members() {
+        this.state = State.PENDING;
+    }
+
+    /**
+     * Single-statement bodies must still carry braces — Checkstyle NeedBraces enforces what the formatter cannot.
+     */
+    public void add(Window window) {
+        if (windows.size() >= MAX) {
+            throw new IllegalStateException("too many windows");
+        }
+        if (window.state().terminal()) {
+            return;
+        }
+        windows.add(window);
+    }
+
+    public State state() {
+        return state;
+    }
+
+    void close() {
+        for (Window window : windows) {
+            if (window.sticky()) {
+                continue;
+            }
+            state = State.CLOSED;
+        }
+        while (!windows.isEmpty()) {
+            windows.remove(windows.size() - 1);
+        }
+    }
+
+    /** An anonymous class body, which has its own brace and indentation rules. */
+    Runnable asTask() {
+        return new Runnable() {
+
+            @Override
+            public void run() {
+                close();
+            }
+        };
+    }
+}

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Wrapping.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Wrapping.java
@@ -1,0 +1,69 @@
+package com.otilm.selftest;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Fixture for the wrapping and continuation-indent settings, which are where the Eclipse profile and IntelliJ's engine
+ * diverge most and therefore where drift shows up first.
+ *
+ * <p>
+ * Every construct here is over the 120-column margin on purpose, so the formatter has to decide where to break and how
+ * far to indent the continuation. Do not "tidy" these lines: their exact shape is the assertion.
+ */
+public final class Wrapping {
+
+    private static final Map<String, List<String>> PRESETS = Map
+            .of("alpha", List.of("one", "two", "three"), "beta", List.of("four", "five", "six"), "gamma",
+                    List.of("seven", "eight", "nine"));
+
+    private final String[] names = {"first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth",
+            "ninth"};
+
+    private Wrapping() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Exercises a long parameter list, a long throws list, and a wrapped binary expression.
+     *
+     * @param source where to read from
+     * @param destination where to write to
+     * @param encoding the charset name
+     * @param overwrite whether an existing destination may be replaced
+     * @return the number of bytes transferred
+     * @throws IOException if either side fails
+     * @throws IllegalStateException if the destination exists and overwrite is false
+     */
+    public static long transfer(Path source, Path destination, String encoding, boolean overwrite)
+            throws IOException, IllegalStateException {
+        if (source == null || destination == null || encoding == null || encoding.isBlank()
+                || !overwrite && destination.toFile().exists()) {
+            throw new IllegalStateException("refusing to transfer with an incomplete or conflicting configuration");
+        }
+        return source.toFile().length() + destination.toFile().length() + encoding.length();
+    }
+
+    /** Exercises a wrapped method-call chain and a wrapped ternary. */
+    public static String describe(List<String> values, boolean verbose) {
+        String joined = values
+                .stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .distinct()
+                .sorted()
+                .reduce("", (left, right) -> left.isEmpty() ? right : left + ", " + right);
+        return verbose ? "values=[" + joined + "] count=" + values.size() + " presets=" + PRESETS.size() : joined;
+    }
+
+    /** Exercises a nested lambda and Optional chaining, both continuation-indent sensitive. */
+    public Optional<String> firstMatching(String prefix) {
+        return List.of(names).stream().filter(name -> name.startsWith(prefix)).findFirst().map(name -> {
+            String upper = name.toUpperCase();
+            return upper.substring(0, 1) + name.substring(1);
+        });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -623,6 +623,12 @@
         <repository>
             <id>central-snapshots</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 
@@ -637,6 +643,9 @@
         <pluginRepository>
             <id>central-snapshots</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,53 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- Linked-worktree fixup, and it must run AFTER the install goal above. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>mirror-hook-into-common-dir</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                                <configuration>
+                                    <target xmlns:if="ant:if">
+                                        <!-- failifexecutionfails: no git on PATH must not break the
+                                             build; the properties stay unset and nothing happens. -->
+                                        <exec executable="git" dir="${project.basedir}" failifexecutionfails="false"
+                                              logError="false" outputproperty="otilm.git.dir">
+                                            <arg value="rev-parse"/>
+                                            <arg value="--git-dir"/>
+                                        </exec>
+                                        <exec executable="git" dir="${project.basedir}" failifexecutionfails="false"
+                                              logError="false" outputproperty="otilm.git.hooks">
+                                            <arg value="rev-parse"/>
+                                            <arg value="--git-path"/>
+                                            <arg value="hooks"/>
+                                        </exec>
+                                        <property name="otilm.hook.installed" location="${otilm.git.dir}/hooks/pre-commit"/>
+                                        <property name="otilm.hook.live" location="${otilm.git.hooks}/pre-commit"/>
+                                        <condition property="otilm.hook.mirror">
+                                            <and>
+                                                <available file="${otilm.hook.installed}" type="file"/>
+                                                <not>
+                                                    <equals arg1="${otilm.hook.installed}" arg2="${otilm.hook.live}"/>
+                                                </not>
+                                            </and>
+                                        </condition>
+                                        <copy if:set="otilm.hook.mirror" file="${otilm.hook.installed}"
+                                              tofile="${otilm.hook.live}" overwrite="true"/>
+                                        <chmod if:set="otilm.hook.mirror" file="${otilm.hook.live}" perm="755"
+                                               osfamily="unix"/>
+                                        <echo if:set="otilm.hook.mirror" level="info"
+                                              message="linked worktree detected: mirrored the pre-commit hook to ${otilm.hook.live}"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -632,14 +679,8 @@
         </repository>
     </repositories>
 
+    <!-- Spotless and Checkstyle read their rules off build-tools, which sits on their PLUGIN classpath. -->
     <pluginRepositories>
-        <pluginRepository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/omnitrustilm/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
         <pluginRepository>
             <id>central-snapshots</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,8 @@
 
     <groupId>com.otilm</groupId>
     <artifactId>dependencies</artifactId>
-    <version>1.4.2</version>
+    <!-- keep in sync with build-tools.version below; the build asserts it -->
+    <version>1.4.3-SNAPSHOT</version>
 
     <name>dependencies</name>
     <packaging>pom</packaging>
@@ -41,6 +42,13 @@
         <developerConnection>scm:git:ssh://git@github.com/OmniTrustILM/dependencies.git</developerConnection>
         <url>https://github.com/OmniTrustILM/dependencies</url>
     </scm>
+
+    <modules>
+        <module>build-tools</module>
+        <!-- Order matters: formatter-selftest runs Spotless against the rules build-tools produces,
+             and a plugin dependency resolves from the reactor only once that module is packaged. -->
+        <module>formatter-selftest</module>
+    </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -80,6 +88,23 @@
         <hibernate-enhance-maven-plugin.version>${hibernate.version}</hibernate-enhance-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
+        <!-- Spotless: both the plugin and the bundled Eclipse JDT formatter are pinned, because
+             .editorconfig is hand-tuned against this exact engine. Bumping either requires re-running the IntelliJ
+             round-trip parity check — procedure documented in build-tools/src/main/resources/otilm/eclipse-formatter.xml.  -->
+        <spotless-maven-plugin.version>3.7.0</spotless-maven-plugin.version>
+        <spotless.eclipse-jdt.version>4.40</spotless.eclipse-jdt.version>
+        <!-- build-tools carries the formatter rules and ships from this reactor, so this must match <version> above.
+             It has to be a literal, not ${project.version}: inherited property values are re-interpolated in each consuming
+             project, so ${project.version} here would resolve to the child repo's own version. -->
+        <build-tools.version>1.4.3-SNAPSHOT</build-tools.version>
+        <!-- Children gate on formatting by default; skip-format-gates-on-aggregator below
+             flips both to true to break the build-tools bootstrap cycle. -->
+        <spotless.skip>false</spotless.skip>
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
+        <checkstyle.version>13.6.0</checkstyle.version>
+        <checkstyle.skip>false</checkstyle.skip>
+        <!-- git-build-hook auto-installs the pre-commit hook. Bound to initialize, so any `mvn …` installs it. -->
+        <git-build-hook-maven-plugin.version>3.6.0</git-build-hook-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -282,6 +307,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>com.rudikershaw.gitbuildhook</groupId>
+                    <artifactId>git-build-hook-maven-plugin</artifactId>
+                    <version>${git-build-hook-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -289,10 +319,239 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
+            <!-- Spotless enforces the canonical Java style. -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless-maven-plugin.version}</version>
+                <configuration>
+                    <skip>${spotless.skip}</skip>
+                    <java>
+                        <includes>
+                            <include>src/main/java/**/*.java</include>
+                            <include>src/test/java/**/*.java</include>
+                        </includes>
+                        <eclipse>
+                            <version>${spotless.eclipse-jdt.version}</version>
+                            <file>otilm/eclipse-formatter.xml</file>
+                        </eclipse>
+                        <importOrder>
+                            <file>otilm/eclipse.importorder</file>
+                        </importOrder>
+                        <removeUnusedImports/>
+                        <trimTrailingWhitespace/>
+                        <endWithNewline/>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.otilm</groupId>
+                        <artifactId>build-tools</artifactId>
+                        <version>${build-tools.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>spotless-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Checkstyle lint gate, closing the four gaps Spotless cannot. The ruleset is
+                 build-tools/src/main/resources/otilm/checkstyle.xml here, and ships in the
+                 build-tools JAR as otilm/checkstyle.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <configuration>
+                    <skip>${checkstyle.skip}</skip>
+                    <configLocation>otilm/checkstyle.xml</configLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <!-- Match Spotless's scope, which is src/{main,test}/java only. -->
+                    <excludeGeneratedSources>true</excludeGeneratedSources>
+                    <failOnViolation>true</failOnViolation>
+                    <violationSeverity>error</violationSeverity>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.otilm</groupId>
+                        <artifactId>build-tools</artifactId>
+                        <version>${build-tools.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>checkstyle-lint</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
+        <!-- Auto-install the pre-commit hook on the first build of a clone. -->
+        <profile>
+            <id>install-git-hooks</id>
+            <activation>
+                <file>
+                    <exists>.git</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.rudikershaw.gitbuildhook</groupId>
+                        <artifactId>git-build-hook-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-git-hooks</id>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Hook source, case 1: a child repo, which has no scripts/ of its own. The install
+             goal searches the filesystem and then the PLUGIN classpath, so shipping
+             pre-commit.sh inside build-tools gives every child the real hook
+             with no per-repo file to copy and keep in sync. -->
+        <profile>
+            <id>hooks-from-build-tools-jar</id>
+            <activation>
+                <file>
+                    <missing>.otilm-aggregator</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.rudikershaw.gitbuildhook</groupId>
+                        <artifactId>git-build-hook-maven-plugin</artifactId>
+                        <configuration>
+                            <installHooks>
+                                <pre-commit>scripts/pre-commit.sh</pre-commit>
+                            </installHooks>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.otilm</groupId>
+                                <artifactId>build-tools</artifactId>
+                                <version>${build-tools.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Hook source, case 2: this repo. Point straight at the working-tree file. -->
+        <profile>
+            <id>hooks-from-source-tree</id>
+            <activation>
+                <file>
+                    <exists>.otilm-aggregator</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.rudikershaw.gitbuildhook</groupId>
+                        <artifactId>git-build-hook-maven-plugin</artifactId>
+                        <configuration>
+                            <installHooks>
+                                <pre-commit>${project.basedir}/scripts/pre-commit.sh</pre-commit>
+                            </installHooks>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Wire local `git blame` to skip the one-shot formatting commit. -->
+        <profile>
+            <id>blame-ignore-revs</id>
+            <activation>
+                <file>
+                    <exists>.git-blame-ignore-revs</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.rudikershaw.gitbuildhook</groupId>
+                        <artifactId>git-build-hook-maven-plugin</artifactId>
+                        <configuration>
+                            <gitConfig>
+                                <blame.ignoreRevsFile>.git-blame-ignore-revs</blame.ignoreRevsFile>
+                            </gitConfig>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>configure-git-blame</id>
+                                <goals>
+                                    <goal>configure</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Skip BOTH format gates when building the dependencies aggregator itself. -->
+        <profile>
+            <id>skip-format-gates-on-aggregator</id>
+            <activation>
+                <file>
+                    <exists>.otilm-aggregator</exists>
+                </file>
+            </activation>
+            <properties>
+                <spotless.skip>true</spotless.skip>
+                <checkstyle.skip>true</checkstyle.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Unbind (not merely skip) the check execution. -->
+                    <plugin>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>spotless-check</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Same bootstrap-cycle fix for Checkstyle (also a build-tools consumer). -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>checkstyle-lint</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>central</id>
             <distributionManagement>
@@ -313,8 +572,9 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <deploymentName>${project.artifactId}-${project.version}</deploymentName>
-                            <!-- autoPublish defaults to false: deployment waits in
-                                 VALIDATED state for you to click Publish in the Portal UI. -->
+                            <excludeArtifacts>
+                                <excludeArtifact>formatter-selftest</excludeArtifact>
+                            </excludeArtifacts>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -365,5 +625,22 @@
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/omnitrustilm/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>central-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "description": "com.otilm:build-tools is not an external dependency: it ships from this very reactor, and build-tools.version must equal this POM's own <version>. maven-enforcer asserts that lockstep (the build-tools-version-lockstep rule in build-tools/pom.xml), so a Renovate PR bumping it to some released build-tools would fail the build rather than update anything. It is bumped by hand as part of a release.",
+      "matchPackageNames": [
+        "com.otilm:build-tools"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run Spotless on the staged Java files and re-stage the result.
+#
+# Auto-installed into .git/hooks/ on the first Maven build of a clone by the
+# git-build-hook-maven-plugin -- there is no manual install step.
+#
+# To bypass for an emergency commit: git commit --no-verify
+# CI (mvn verify) remains the authoritative gate either way.
+#
+# -----------------------------------------------------------------------------
+# Portability contract. Every item here has broken this hook before; re-run
+# scripts/test-pre-commit.sh after editing.
+#
+#   bash 3.2   macOS ships 3.2.57 as /bin/bash and GUI git clients hand hooks a
+#              reduced PATH, so `mapfile` (bash 4.0) is unavailable -- and under
+#              `set -u`, "${arr[@]}" on an EMPTY array is an "unbound variable"
+#              error before bash 4.4, hence the ${arr[@]+"${arr[@]}"} guards.
+#   Git Bash   git reports forward-slash paths, the JVM reports backslash ones.
+#   paths      -DspotlessFiles is a REGEX, not a path list. See below.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+warn() { printf 'pre-commit: %s\n' "$*" >&2; }
+die() {
+    warn "$*"
+    exit 1
+}
+
+repo_root=$(git rev-parse --show-toplevel) ||
+    die 'cannot locate the work tree root (not a git repository, or git not on PATH)'
+cd "$repo_root"
+
+# A missing build tool must not make committing impossible: warn and let the
+# commit through, because `mvn verify` in CI still gates the branch.
+if [ -x ./mvnw ]; then
+    maven=./mvnw
+elif command -v mvn >/dev/null 2>&1; then
+    maven=mvn
+else
+    warn 'neither ./mvnw nor mvn on PATH; skipping Spotless (CI still gates this)'
+    exit 0
+fi
+
+# Collect the staged Java files. bash 3.2 has no `mapfile`, so read the
+# NUL-delimited list with a loop. ACMR rather than ACM: a rename (R) carries
+# content that still needs formatting.
+staged=()
+while IFS= read -r -d '' file; do
+    staged+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.java')
+
+[ "${#staged[@]}" -ne 0 ] || exit 0
+
+# `git add` stages a file's CURRENT WORKTREE content, not the formatted version of what was staged.
+formattable=()
+partial=()
+for file in ${staged[@]+"${staged[@]}"}; do
+    if git diff --quiet -- "$file"; then
+        formattable+=("$file")
+    else
+        partial+=("$file")
+    fi
+done
+
+if [ "${#partial[@]}" -ne 0 ]; then
+    warn 'left alone -- these have unstaged changes that re-staging would sweep into the commit:'
+    for file in ${partial[@]+"${partial[@]}"}; do warn "    $file"; done
+    warn 'stage them completely, or run "mvn spotless:apply" yourself, before pushing.'
+fi
+
+[ "${#formattable[@]}" -ne 0 ] || exit 0
+
+# -DspotlessFiles is NOT a list of paths: spotless-maven-plugin splits the value
+# on ',', Pattern.compile()s each piece, and full-matches it against
+# File.getAbsolutePath(). Three consequences:
+#
+#   * the path must be spelled the way the JVM will spell it -- backslashes on
+#     Windows, where git hands us forward slashes; hence cygpath.
+#   * every path must be regex-quoted with \Q..\E. Without it a directory named
+#     "Program Files (x86)" matches NOTHING, Spotless formats nothing, and the
+#     build still exits 0 -- a silent no-op that lands unformatted code.
+#   * a ',' in a path cannot survive the plugin's split(), so such a file is
+#     reported and skipped rather than silently mis-matched.
+case $(uname -s) in
+MINGW* | MSYS* | CYGWIN*) windows=1 ;;
+*) windows=0 ;;
+esac
+
+patterns=''
+targets=()
+uncommaable=()
+for file in ${formattable[@]+"${formattable[@]}"}; do
+    abs="$repo_root/$file"
+    if [ "$windows" -eq 1 ] && command -v cygpath >/dev/null 2>&1; then
+        abs=$(cygpath -w -- "$abs")
+    fi
+    case $abs in
+    *,*)
+        uncommaable+=("$file")
+        continue
+        ;;
+    esac
+    patterns="${patterns:+$patterns,}\\Q$abs\\E"
+    targets+=("$file")
+done
+
+if [ "${#uncommaable[@]}" -ne 0 ]; then
+    warn 'left alone -- a comma in the path cannot be passed through -DspotlessFiles:'
+    for file in ${uncommaable[@]+"${uncommaable[@]}"}; do warn "    $file"; done
+fi
+
+[ -n "$patterns" ] || exit 0
+
+# Deliberately not -q: the "Spotless.Java is keeping N files clean" line is the
+# only evidence that the regex above actually matched, and -q suppresses it.
+# MSYS2_ARG_CONV_EXCL stops Git Bash from rewriting the "C:\..." inside the
+# argument as though it were a POSIX path list.
+if ! output=$(MSYS2_ARG_CONV_EXCL='-DspotlessFiles' \
+    "$maven" -B spotless:apply -DspotlessFiles="$patterns" 2>&1); then
+    printf '%s\n' "$output" >&2
+    die 'mvn spotless:apply failed; nothing was re-staged'
+fi
+
+# Confirm Spotless actually saw the files we asked for. The count is printed once
+# per module, so sum it across the reactor. A total of zero means the
+# path-to-regex translation above is wrong for this platform -- the failure mode
+# that otherwise passes silently and commits unformatted code.
+matched=$(printf '%s\n' "$output" | awk '
+    match($0, /Spotless\.Java is keeping [0-9]+ files clean/) {
+        n = substr($0, RSTART, RLENGTH)
+        gsub(/[^0-9]/, "", n)
+        total += n
+    }
+    END { print total + 0 }
+')
+
+if [ "$matched" -eq 0 ]; then
+    printf '%s\n' "$output" >&2
+    die "Spotless matched none of the ${#targets[@]} staged file(s). Either this hook's
+            path handling is wrong on this platform (please report it), or the files sit
+            outside the configured Spotless <includes>. Commit blocked rather than
+            silently committing unformatted code; use --no-verify to override."
+elif [ "$matched" -lt "${#targets[@]}" ]; then
+    warn "Spotless matched only $matched of the ${#targets[@]} staged file(s); the rest are
+            probably outside its configured <includes> and remain unformatted."
+fi
+
+git add -- ${targets[@]+"${targets[@]}"}

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -32,7 +32,7 @@ cd "$repo_root"
 
 # A missing build tool must not make committing impossible: warn and let the
 # commit through, because `mvn verify` in CI still gates the branch.
-if [ -x ./mvnw ]; then
+if [[ -x ./mvnw ]]; then
     maven=./mvnw
 elif command -v mvn >/dev/null 2>&1; then
     maven=mvn
@@ -49,7 +49,7 @@ while IFS= read -r -d '' file; do
     staged+=("$file")
 done < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.java')
 
-[ "${#staged[@]}" -ne 0 ] || exit 0
+[[ "${#staged[@]}" -ne 0 ]] || exit 0
 
 # `git add` stages a file's CURRENT WORKTREE content, not the formatted version of what was staged.
 formattable=()
@@ -62,23 +62,26 @@ for file in ${staged[@]+"${staged[@]}"}; do
     fi
 done
 
-if [ "${#partial[@]}" -ne 0 ]; then
+if [[ "${#partial[@]}" -ne 0 ]]; then
     warn 'left alone -- these have unstaged changes that re-staging would sweep into the commit:'
     for file in ${partial[@]+"${partial[@]}"}; do warn "    $file"; done
     warn 'stage them completely, or run "mvn spotless:apply" yourself, before pushing.'
 fi
 
-[ "${#formattable[@]}" -ne 0 ] || exit 0
+[[ "${#formattable[@]}" -ne 0 ]] || exit 0
 
 # -DspotlessFiles is NOT a list of paths: spotless-maven-plugin splits the value
 # on ',', Pattern.compile()s each piece, and full-matches it against
-# File.getAbsolutePath(). Three consequences:
+# File.getAbsolutePath(). Four consequences:
 #
 #   * the path must be spelled the way the JVM will spell it -- backslashes on
 #     Windows, where git hands us forward slashes; hence cygpath.
 #   * every path must be regex-quoted with \Q..\E. Without it a directory named
 #     "Program Files (x86)" matches NOTHING, Spotless formats nothing, and the
 #     build still exits 0 -- a silent no-op that lands unformatted code.
+#   * \Q..\E is not itself nestable: a literal \E INSIDE the path closes the
+#     quoted span early and the remainder is read as raw regex. Consider
+#     "C:\Eclipse\..." on Windows.
 #   * a ',' in a path cannot survive the plugin's split(), so such a file is
 #     reported and skipped rather than silently mis-matched.
 case $(uname -s) in
@@ -91,7 +94,7 @@ targets=()
 uncommaable=()
 for file in ${formattable[@]+"${formattable[@]}"}; do
     abs="$repo_root/$file"
-    if [ "$windows" -eq 1 ] && command -v cygpath >/dev/null 2>&1; then
+    if [[ "$windows" -eq 1 ]] && command -v cygpath >/dev/null 2>&1; then
         abs=$(cygpath -w -- "$abs")
     fi
     case $abs in
@@ -99,17 +102,19 @@ for file in ${formattable[@]+"${formattable[@]}"}; do
         uncommaable+=("$file")
         continue
         ;;
+    *) ;; # every other path is usable as-is; fall through to the quoting below
     esac
-    patterns="${patterns:+$patterns,}\\Q$abs\\E"
+    esc=${abs//'\E'/'\E\\E\Q'}
+    patterns="${patterns:+$patterns,}\\Q$esc\\E"
     targets+=("$file")
 done
 
-if [ "${#uncommaable[@]}" -ne 0 ]; then
+if [[ "${#uncommaable[@]}" -ne 0 ]]; then
     warn 'left alone -- a comma in the path cannot be passed through -DspotlessFiles:'
     for file in ${uncommaable[@]+"${uncommaable[@]}"}; do warn "    $file"; done
 fi
 
-[ -n "$patterns" ] || exit 0
+[[ -n "$patterns" ]] || exit 0
 
 # Deliberately not -q: the "Spotless.Java is keeping N files clean" line is the
 # only evidence that the regex above actually matched, and -q suppresses it.
@@ -134,13 +139,13 @@ matched=$(printf '%s\n' "$output" | awk '
     END { print total + 0 }
 ')
 
-if [ "$matched" -eq 0 ]; then
+if [[ "$matched" -eq 0 ]]; then
     printf '%s\n' "$output" >&2
     die "Spotless matched none of the ${#targets[@]} staged file(s). Either this hook's
             path handling is wrong on this platform (please report it), or the files sit
             outside the configured Spotless <includes>. Commit blocked rather than
             silently committing unformatted code; use --no-verify to override."
-elif [ "$matched" -lt "${#targets[@]}" ]; then
+elif [[ "$matched" -lt "${#targets[@]}" ]]; then
     warn "Spotless matched only $matched of the ${#targets[@]} staged file(s); the rest are
             probably outside its configured <includes> and remain unformatted."
 fi

--- a/scripts/test-pre-commit.sh
+++ b/scripts/test-pre-commit.sh
@@ -210,7 +210,7 @@ staged_content src/main/java/A.java >"$REPO/.idx"
 assert_not_contains "$REPO/.idx" UNFORMATTED 'index holds the formatted content'
 assert_not_contains "$REPO/src/main/java/A.java" UNFORMATTED 'worktree holds the formatted content'
 
-# The blocker: a file staged in part must not have its unstaged remainder swept in.
+# A file staged in part must not have its unstaged remainder swept in.
 begin preserves_unstaged_changes
 java_file src/main/java/A.java UNFORMATTED
 (
@@ -458,8 +458,8 @@ if [[ "${E2E:-0}" = 1 ]]; then
   </plugin></plugins></build>
 </project>
 POM
-    # A directory whose name is full of regex metacharacters: unquoted, this is
-    # the silent no-op that shipped in the first version of this hook.
+    # A directory whose name is full of regex metacharacters. Without regex quoting,
+    # -DspotlessFiles matches nothing here and the hook formats no files at all.
     mkdir -p "$REPO/src/main/java/weird (x86)+dir"
     printf 'package p;\nimport java.util.List;\nclass C { }\n' \
         >"$REPO/src/main/java/weird (x86)+dir/C.java"

--- a/scripts/test-pre-commit.sh
+++ b/scripts/test-pre-commit.sh
@@ -156,8 +156,6 @@ new_repo() {
         git config commit.gpgsign false
         git config core.hooksPath .git/hooks
     ) || {
-        # Without this the suite runs every case against a directory that is not a
-        # repository, and reports a wall of assertion failures instead of the cause.
         echo "cannot create the fixture repo for case '$CASE' -- is git working?" >&2
         exit 1
     }

--- a/scripts/test-pre-commit.sh
+++ b/scripts/test-pre-commit.sh
@@ -65,7 +65,12 @@ assert_contains() {
 
 assert_not_contains() {
     local haystack_file=$1 needle=$2 label=$3
-    if grep -qF -- "$needle" "$haystack_file" 2>/dev/null; then
+    # A missing or empty haystack satisfies "does not contain" without testing
+    # anything, so a broken fixture would read as a pass. Every haystack here is
+    # a file that must exist and hold content by the time it is checked.
+    if [[ ! -s "$haystack_file" ]]; then
+        no "$label (no content at $haystack_file)"
+    elif grep -qF -- "$needle" "$haystack_file" 2>/dev/null; then
         no "$label (unexpectedly present: $needle)"
     else ok "$label"; fi
     return 0
@@ -150,7 +155,12 @@ new_repo() {
         git config user.name Test
         git config commit.gpgsign false
         git config core.hooksPath .git/hooks
-    )
+    ) || {
+        # Without this the suite runs every case against a directory that is not a
+        # repository, and reports a wall of assertion failures instead of the cause.
+        echo "cannot create the fixture repo for case '$CASE' -- is git working?" >&2
+        exit 1
+    }
     return 0
 }
 

--- a/scripts/test-pre-commit.sh
+++ b/scripts/test-pre-commit.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# Test harness for scripts/pre-commit.sh.
+#
+# Self-contained: builds throwaway git repos in a temp directory and puts a stub
+# `mvn` on PATH, so no JDK, no Maven and no network are needed. The stub mimics
+# the one behaviour of spotless-maven-plugin the hook depends on -- it reports
+# how many files its -DspotlessFiles regex matched -- which is what lets the
+# no-op detection be tested at all.
+#
+# Usage:
+#   scripts/test-pre-commit.sh              # test with the bash on PATH
+#   TEST_BASH=/bin/bash scripts/test-pre-commit.sh
+#
+# This harness must itself stay bash 3.2 compatible; it is run under 3.2 in CI.
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+HOOK="$HERE/pre-commit.sh"
+# Resolved to an absolute path: one case below runs the hook with a PATH that
+# deliberately contains nothing but git, and a bare "bash" would not be found.
+TEST_BASH=$(command -v "${TEST_BASH:-bash}") || {
+    echo "no bash found for TEST_BASH=${TEST_BASH:-bash}" >&2
+    exit 1
+}
+
+[ -f "$HOOK" ] || {
+    echo "no hook at $HOOK" >&2
+    exit 1
+}
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/pre-commit-tests-XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_CASES=''
+
+# --- assertions ---------------------------------------------------------------
+
+ok() {
+    PASS=$((PASS + 1))
+    printf '    ok   %s\n' "$1"
+}
+
+no() {
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES
+  - $CASE: $1"
+    printf '    FAIL %s\n' "$1"
+}
+
+assert_contains() { # haystack-file needle label
+    if grep -qF -- "$2" "$1" 2>/dev/null; then ok "$3"; else
+        no "$3 (missing: $2)"
+    fi
+}
+
+assert_not_contains() { # haystack-file needle label
+    if grep -qF -- "$2" "$1" 2>/dev/null; then
+        no "$3 (unexpectedly present: $2)"
+    else ok "$3"; fi
+}
+
+assert_eq() { # actual expected label
+    if [ "$1" = "$2" ]; then ok "$3"; else no "$3 (got '$1', want '$2')"; fi
+}
+
+# --- fixtures ----------------------------------------------------------------
+
+# The stub records its argv, emulates the plugin's \Q..\E unquoting, "formats"
+# each file it matched by deleting UNFORMATTED lines, and prints the count line.
+# STUB_MODE: normal | noop (print no count line) | partial (undercount) | fail |
+# winpath (treat the pattern as a Windows path, the way a JVM on Windows would).
+write_stub_mvn() {
+    cat >"$1/mvn" <<'STUB'
+#!/usr/bin/env bash
+set -f
+printf '%s\n' "$*" >> "$STUB_LOG"
+printf 'MSYS2_ARG_CONV_EXCL=%s\n' "${MSYS2_ARG_CONV_EXCL:-unset}" >> "$STUB_LOG"
+mode=${STUB_MODE:-normal}
+if [ "$mode" = fail ]; then echo "[ERROR] stub maven failure"; exit 1; fi
+pat=''
+for a in "$@"; do
+    case $a in -DspotlessFiles=*) pat=${a#-DspotlessFiles=} ;; esac
+done
+n=0
+oldifs=$IFS
+IFS=','
+for p in $pat; do
+    IFS=$oldifs
+    q=${p#'\Q'}; q=${q%'\E'}
+    # A JVM on Windows resolves "C:\a\b"; this test filesystem holds "/a/b".
+    if [ "$mode" = winpath ]; then
+        case $q in
+            [A-Za-z]:\\*) q=$(printf '%s' "$q" | sed -e 's|^[A-Za-z]:||' -e 's|\\|/|g') ;;
+        esac
+    fi
+    if [ -f "$q" ]; then
+        n=$((n + 1))
+        grep -v 'UNFORMATTED' "$q" > "$q.stub" 2>/dev/null || true
+        mv "$q.stub" "$q"
+    fi
+    IFS=','
+done
+IFS=$oldifs
+case $mode in
+    noop) ;;
+    partial) echo "[INFO] Spotless.Java is keeping $((n > 1 ? n - 1 : 0)) files clean - 0 were changed to be clean" ;;
+    *) echo "[INFO] Spotless.Java is keeping $n files clean - $n were changed to be clean, 0 were already clean, 0 were skipped" ;;
+esac
+exit 0
+STUB
+    chmod +x "$1/mvn"
+}
+
+# A fresh repo with the hook available. Sets: REPO, BIN, STUB_LOG.
+new_repo() {
+    REPO="$WORK/$CASE"
+    BIN="$REPO/.bin"
+    STUB_LOG="$REPO/.mvn-argv"
+    mkdir -p "$REPO" "$BIN"
+    : >"$STUB_LOG"
+    write_stub_mvn "$BIN"
+    (
+        cd "$REPO" || exit 1
+        git init -q .
+        git config user.email t@example.com
+        git config user.name Test
+        git config commit.gpgsign false
+        git config core.hooksPath .git/hooks
+    )
+}
+
+java_file() { # path marker
+    mkdir -p "$REPO/$(dirname "$1")"
+    printf 'package p;\nclass C { }\n%s\n' "${2:-}" >"$REPO/$1"
+}
+
+# Run the hook the way git would, but under $TEST_BASH. Sets HOOK_RC, HOOK_OUT.
+run_hook() {
+    HOOK_OUT="$REPO/.hook-out"
+    (
+        cd "$REPO" || exit 1
+        PATH="$BIN:$PATH" STUB_LOG="$STUB_LOG" STUB_MODE="${STUB_MODE:-normal}" \
+            "$TEST_BASH" "$HOOK" >"$HOOK_OUT" 2>&1
+    )
+    HOOK_RC=$?
+}
+
+staged_content() { # path -> stdout
+    (cd "$REPO" && git show ":$1" 2>/dev/null)
+}
+
+begin() {
+    CASE="$1"
+    STUB_MODE=normal
+    printf '\n== %s\n' "$1"
+    new_repo
+}
+
+# --- cases -------------------------------------------------------------------
+
+begin no_java_staged
+echo hi >"$REPO/notes.txt"
+(cd "$REPO" && git add notes.txt)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$(wc -l <"$STUB_LOG" | tr -d ' ')" 0 'never invokes maven'
+
+begin nothing_staged
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0 on an empty index'
+
+begin formats_and_restages
+java_file src/main/java/A.java UNFORMATTED
+(cd "$REPO" && git add src/main/java/A.java)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0'
+staged_content src/main/java/A.java >"$REPO/.idx"
+assert_not_contains "$REPO/.idx" UNFORMATTED 'index holds the formatted content'
+assert_not_contains "$REPO/src/main/java/A.java" UNFORMATTED 'worktree holds the formatted content'
+
+# The blocker: a file staged in part must not have its unstaged remainder swept in.
+begin preserves_unstaged_changes
+java_file src/main/java/A.java UNFORMATTED
+(
+    cd "$REPO" && git add src/main/java/A.java && git commit -qm init --no-verify
+    printf 'package p;\nclass C { }\nUNFORMATTED\nSTAGED_EDIT\n' >src/main/java/A.java
+    git add src/main/java/A.java
+    printf 'package p;\nclass C { }\nUNFORMATTED\nSTAGED_EDIT\nSECRET_UNSTAGED\n' >src/main/java/A.java
+)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0'
+staged_content src/main/java/A.java >"$REPO/.idx"
+assert_not_contains "$REPO/.idx" SECRET_UNSTAGED 'unstaged line stays OUT of the index'
+assert_contains "$REPO/src/main/java/A.java" SECRET_UNSTAGED 'unstaged line survives in the worktree'
+assert_contains "$HOOK_OUT" 'unstaged changes' 'warns about the partially staged file'
+assert_eq "$(wc -l <"$STUB_LOG" | tr -d ' ')" 0 'does not ask maven to format it'
+
+begin mixed_clean_and_partial
+java_file src/main/java/Clean.java UNFORMATTED
+java_file src/main/java/Partial.java UNFORMATTED
+(
+    cd "$REPO" && git add . && git commit -qm init --no-verify
+    printf 'package p;\nclass C { }\nUNFORMATTED\nx\n' >src/main/java/Clean.java
+    printf 'package p;\nclass C { }\nUNFORMATTED\ny\n' >src/main/java/Partial.java
+    git add src/main/java/Clean.java src/main/java/Partial.java
+    printf 'package p;\nclass C { }\nUNFORMATTED\ny\nEXTRA\n' >src/main/java/Partial.java
+)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0'
+staged_content src/main/java/Clean.java >"$REPO/.c"
+staged_content src/main/java/Partial.java >"$REPO/.p"
+assert_not_contains "$REPO/.c" UNFORMATTED 'clean file is formatted'
+assert_contains "$REPO/.p" UNFORMATTED 'partial file is left alone'
+assert_not_contains "$REPO/.p" EXTRA 'partial file keeps its unstaged line out of the index'
+
+# Regex metacharacters and spaces in the path: the silent-no-op class of bug.
+begin path_with_metachars
+java_file 'src/main/java/weird (x86)+dir/A.java' UNFORMATTED
+(cd "$REPO" && git add .)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0'
+assert_contains "$STUB_LOG" '\Q' 'passes a regex-quoted pattern'
+assert_contains "$STUB_LOG" 'weird (x86)+dir' 'pattern carries the literal directory name'
+assert_not_contains "$REPO/src/main/java/weird (x86)+dir/A.java" UNFORMATTED 'file with metachars is formatted'
+
+begin filename_with_spaces
+java_file 'src/main/java/My Class.java' UNFORMATTED
+(cd "$REPO" && git add .)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0'
+assert_not_contains "$REPO/src/main/java/My Class.java" UNFORMATTED 'file with a space is formatted'
+
+begin path_with_comma_is_skipped
+java_file 'src/main/java/a,b/A.java' UNFORMATTED
+(cd "$REPO" && git add .)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0 rather than mis-matching'
+assert_contains "$HOOK_OUT" 'comma in the path' 'reports the comma path'
+assert_eq "$(wc -l <"$STUB_LOG" | tr -d ' ')" 0 'never invokes maven with an unsplittable value'
+
+begin rename_is_formatted
+java_file src/main/java/Old.java UNFORMATTED
+(
+    cd "$REPO" && git add . && git commit -qm init --no-verify
+    git mv src/main/java/Old.java src/main/java/New.java
+)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0'
+assert_contains "$STUB_LOG" New.java 'a rename is offered to Spotless (ACMR, not ACM)'
+
+begin missing_maven_does_not_block
+java_file src/main/java/A.java UNFORMATTED
+(cd "$REPO" && git add .)
+# A PATH holding everything the hook needs except a build tool. Built out of
+# wrapper scripts that exec the real absolute paths.
+nomvn="$REPO/.nomvn"
+mkdir -p "$nomvn"
+for cmd in git awk uname cygpath; do
+    real=$(command -v "$cmd" 2>/dev/null) || continue
+    [ -n "$real" ] || continue
+    printf '#!/bin/sh\nexec "%s" "$@"\n' "$real" >"$nomvn/$cmd"
+    chmod +x "$nomvn/$cmd"
+done
+HOOK_OUT="$REPO/.hook-out"
+(cd "$REPO" && PATH="$nomvn" "$TEST_BASH" "$HOOK" >"$HOOK_OUT" 2>&1)
+HOOK_RC=$?
+assert_eq "$HOOK_RC" 0 'exits 0 when there is no build tool'
+assert_contains "$HOOK_OUT" 'skipping Spotless' 'says why it skipped'
+
+begin prefers_mvnw
+java_file src/main/java/A.java UNFORMATTED
+cp "$BIN/mvn" "$REPO/mvnw"
+chmod +x "$REPO/mvnw"
+(cd "$REPO" && git add src/main/java/A.java)
+rm -f "$BIN/mvn" # only ./mvnw is available
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0 using ./mvnw'
+assert_contains "$STUB_LOG" spotless:apply 'invoked the wrapper'
+
+begin silent_noop_blocks_commit
+STUB_MODE=noop
+java_file src/main/java/A.java UNFORMATTED
+(cd "$REPO" && git add . && git commit -qm init --no-verify)
+(cd "$REPO" && printf 'package p;\nclass C { }\nUNFORMATTED\nz\n' >src/main/java/A.java && git add .)
+run_hook
+if [ "$HOOK_RC" -ne 0 ]; then ok 'blocks the commit when Spotless matched nothing'; else
+    no 'blocks the commit when Spotless matched nothing (exited 0)'
+fi
+assert_contains "$HOOK_OUT" 'matched none' 'explains the no-op'
+
+begin undercount_warns_but_proceeds
+STUB_MODE=partial
+java_file src/main/java/A.java UNFORMATTED
+java_file src/main/java/B.java UNFORMATTED
+(cd "$REPO" && git add .)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0 on a partial match'
+assert_contains "$HOOK_OUT" 'matched only' 'warns about the unmatched remainder'
+
+begin maven_failure_blocks_commit
+STUB_MODE=fail
+java_file src/main/java/A.java UNFORMATTED
+(cd "$REPO" && git add .)
+run_hook
+if [ "$HOOK_RC" -ne 0 ]; then ok 'blocks the commit when maven fails'; else
+    no 'blocks the commit when maven fails (exited 0)'
+fi
+assert_contains "$HOOK_OUT" 'stub maven failure' 'surfaces the maven output'
+
+begin runs_from_a_subdirectory
+java_file src/main/java/deep/A.java UNFORMATTED
+(cd "$REPO" && git add .)
+HOOK_OUT="$REPO/.hook-out"
+(
+    cd "$REPO/src/main/java/deep" &&
+        PATH="$BIN:$PATH" STUB_LOG="$STUB_LOG" STUB_MODE=normal \
+            "$TEST_BASH" "$HOOK" >"$HOOK_OUT" 2>&1
+)
+HOOK_RC=$?
+assert_eq "$HOOK_RC" 0 'exits 0'
+assert_not_contains "$REPO/src/main/java/deep/A.java" UNFORMATTED 'resolves the repo root from a subdirectory'
+
+# End to end: installed as a real hook and driven by `git commit`, so the shebang
+# and git's own hook invocation are exercised rather than bypassed.
+begin end_to_end_git_commit
+java_file src/main/java/A.java UNFORMATTED
+cp "$HOOK" "$REPO/.git/hooks/pre-commit"
+chmod +x "$REPO/.git/hooks/pre-commit"
+COMMIT_OUT="$REPO/.commit-out"
+(
+    cd "$REPO" && git add src/main/java/A.java &&
+        PATH="$BIN:$(dirname "$(command -v "$TEST_BASH")"):$PATH" \
+            STUB_LOG="$STUB_LOG" STUB_MODE=normal \
+            git commit -qm formatted >"$COMMIT_OUT" 2>&1
+)
+COMMIT_RC=$?
+assert_eq "$COMMIT_RC" 0 'git commit succeeds'
+(cd "$REPO" && git show HEAD:src/main/java/A.java 2>/dev/null) >"$REPO/.head"
+assert_not_contains "$REPO/.head" UNFORMATTED 'the commit contains formatted content'
+
+# Simulated Git Bash, for machines that are not Windows. Proves the Windows branch
+# converts the path with cygpath, regex-quotes the backslash form, and sets
+# MSYS2_ARG_CONV_EXCL so Git Bash does not rewrite the "C:\..." inside the
+# argument.
+#
+# Skipped when already on Windows, where it would be both redundant and wrong:
+# redundant because `uname -s` really is MINGW there, so every case above already
+# ran through the real cygpath; wrong because the stub cygpath below cannot
+# faithfully reverse a real drive-letter path back to a POSIX one.
+case $(uname -s) in
+MINGW* | MSYS* | CYGWIN*)
+    printf '\n== windows_path_translation\n'
+    printf '    skipped: on Windows already -- every case above used the real cygpath\n'
+    ;;
+*)
+    begin windows_path_translation
+    STUB_MODE=winpath
+cat >"$BIN/uname" <<'FAKE_UNAME'
+#!/bin/sh
+echo MINGW64_NT-10.0-22631
+FAKE_UNAME
+cat >"$BIN/cygpath" <<'FAKE_CYGPATH'
+#!/bin/sh
+# emulate: cygpath -w -- /a/b  ->  C:\a\b
+last=''
+for a in "$@"; do last=$a; done
+printf '%s\n' "$last" | sed -e 's|^/|C:/|' -e 's|/|\\|g'
+FAKE_CYGPATH
+chmod +x "$BIN/uname" "$BIN/cygpath"
+java_file 'src/main/java/Program Files (x86)/A.java' UNFORMATTED
+(cd "$REPO" && git add .)
+run_hook
+assert_eq "$HOOK_RC" 0 'exits 0 under a simulated Git Bash'
+assert_contains "$STUB_LOG" '\QC:\' 'builds a regex-quoted backslash Windows pattern'
+assert_contains "$STUB_LOG" 'MSYS2_ARG_CONV_EXCL=-DspotlessFiles' 'guards against MSYS argument mangling'
+    assert_not_contains "$REPO/src/main/java/Program Files (x86)/A.java" UNFORMATTED \
+        'formats a Windows-style path containing spaces and metacharacters'
+    ;;
+esac
+
+# --- opt-in: the real plugin, no stub ----------------------------------------
+# E2E=1 drives the whole chain through the real spotless-maven-plugin. That is
+# the only way to check the \Q..\E construction against Java's actual regex
+# semantics rather than the stub's imitation of them, so run it whenever the
+# path handling above changes. Needs Maven, a JDK and (on a cold cache) the
+# network, hence opt-in. The plugin version is read from the parent POM so this
+# test cannot drift away from what the BOM ships.
+if [ "${E2E:-0}" = 1 ]; then
+    begin e2e_real_spotless
+    SPOTLESS_VERSION=$(sed -n \
+        's/.*<spotless-maven-plugin\.version>\([^<]*\)<.*/\1/p' "$HERE/../pom.xml" | head -1)
+    printf 'spotless-maven-plugin version under test: %s\n' "${SPOTLESS_VERSION:-UNKNOWN}"
+    cat >"$REPO/pom.xml" <<POM
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>e2e</groupId><artifactId>e2e</artifactId><version>1</version>
+  <build><plugins><plugin>
+    <groupId>com.diffplug.spotless</groupId>
+    <artifactId>spotless-maven-plugin</artifactId>
+    <version>$SPOTLESS_VERSION</version>
+    <configuration><java>
+      <includes><include>src/main/java/**/*.java</include></includes>
+      <removeUnusedImports/>
+    </java></configuration>
+  </plugin></plugins></build>
+</project>
+POM
+    # A directory whose name is full of regex metacharacters: unquoted, this is
+    # the silent no-op that shipped in the first version of this hook.
+    mkdir -p "$REPO/src/main/java/weird (x86)+dir"
+    printf 'package p;\nimport java.util.List;\nclass C { }\n' \
+        >"$REPO/src/main/java/weird (x86)+dir/C.java"
+    (cd "$REPO" && git add .)
+    HOOK_OUT="$REPO/.hook-out"
+    (cd "$REPO" && "$TEST_BASH" "$HOOK" >"$HOOK_OUT" 2>&1)
+    HOOK_RC=$?
+    assert_eq "$HOOK_RC" 0 'exits 0 with the real plugin'
+    staged_content 'src/main/java/weird (x86)+dir/C.java' >"$REPO/.idx"
+    assert_not_contains "$REPO/.idx" 'import java.util.List' \
+        'real Spotless formatted a metacharacter path and the result was staged'
+fi
+
+# --- summary -----------------------------------------------------------------
+
+printf '\n--------------------------------------------------\n'
+printf 'bash under test: %s\n' "$("$TEST_BASH" -c 'echo $BASH_VERSION')"
+printf 'git:             %s\n' "$(git --version)"
+printf 'passed: %s   failed: %s\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+    printf 'failures:%s\n' "$FAILED_CASES"
+    exit 1
+fi
+printf 'ALL GREEN\n'

--- a/scripts/test-pre-commit.sh
+++ b/scripts/test-pre-commit.sh
@@ -23,7 +23,7 @@ TEST_BASH=$(command -v "${TEST_BASH:-bash}") || {
     exit 1
 }
 
-[ -f "$HOOK" ] || {
+[[ -f "$HOOK" ]] || {
     echo "no hook at $HOOK" >&2
     exit 1
 }
@@ -37,32 +37,46 @@ FAILED_CASES=''
 
 # --- assertions ---------------------------------------------------------------
 
+readonly EXITS_0='exits 0'
+
 ok() {
+    local label=$1
     PASS=$((PASS + 1))
-    printf '    ok   %s\n' "$1"
+    printf '    ok   %s\n' "$label"
+    return 0
 }
 
 no() {
+    local label=$1
     FAIL=$((FAIL + 1))
     FAILED_CASES="$FAILED_CASES
-  - $CASE: $1"
-    printf '    FAIL %s\n' "$1"
+  - $CASE: $label"
+    printf '    FAIL %s\n' "$label"
+    return 0
 }
 
-assert_contains() { # haystack-file needle label
-    if grep -qF -- "$2" "$1" 2>/dev/null; then ok "$3"; else
-        no "$3 (missing: $2)"
+assert_contains() {
+    local haystack_file=$1 needle=$2 label=$3
+    if grep -qF -- "$needle" "$haystack_file" 2>/dev/null; then ok "$label"; else
+        no "$label (missing: $needle)"
     fi
+    return 0
 }
 
-assert_not_contains() { # haystack-file needle label
-    if grep -qF -- "$2" "$1" 2>/dev/null; then
-        no "$3 (unexpectedly present: $2)"
-    else ok "$3"; fi
+assert_not_contains() {
+    local haystack_file=$1 needle=$2 label=$3
+    if grep -qF -- "$needle" "$haystack_file" 2>/dev/null; then
+        no "$label (unexpectedly present: $needle)"
+    else ok "$label"; fi
+    return 0
 }
 
-assert_eq() { # actual expected label
-    if [ "$1" = "$2" ]; then ok "$3"; else no "$3 (got '$1', want '$2')"; fi
+assert_eq() {
+    local actual=$1 expected=$2 label=$3
+    if [[ "$actual" = "$expected" ]]; then ok "$label"; else
+        no "$label (got '$actual', want '$expected')"
+    fi
+    return 0
 }
 
 # --- fixtures ----------------------------------------------------------------
@@ -72,13 +86,14 @@ assert_eq() { # actual expected label
 # STUB_MODE: normal | noop (print no count line) | partial (undercount) | fail |
 # winpath (treat the pattern as a Windows path, the way a JVM on Windows would).
 write_stub_mvn() {
-    cat >"$1/mvn" <<'STUB'
+    local bindir=$1
+    cat >"$bindir/mvn" <<'STUB'
 #!/usr/bin/env bash
 set -f
 printf '%s\n' "$*" >> "$STUB_LOG"
 printf 'MSYS2_ARG_CONV_EXCL=%s\n' "${MSYS2_ARG_CONV_EXCL:-unset}" >> "$STUB_LOG"
 mode=${STUB_MODE:-normal}
-if [ "$mode" = fail ]; then echo "[ERROR] stub maven failure"; exit 1; fi
+if [[ "$mode" = fail ]]; then echo "[ERROR] stub maven failure"; exit 1; fi
 pat=''
 for a in "$@"; do
     case $a in -DspotlessFiles=*) pat=${a#-DspotlessFiles=} ;; esac
@@ -89,13 +104,19 @@ IFS=','
 for p in $pat; do
     IFS=$oldifs
     q=${p#'\Q'}; q=${q%'\E'}
+    # Undo Pattern.quote()'s escaping of an embedded \E.
+    probe=${q//'\E\\E\Q'/$'\001'}
+    case $probe in
+        *'\E'*) IFS=','; continue ;; # malformed: not a literal quote of any path
+        *) q=${probe//$'\001'/'\E'} ;;
+    esac
     # A JVM on Windows resolves "C:\a\b"; this test filesystem holds "/a/b".
-    if [ "$mode" = winpath ]; then
+    if [[ "$mode" = winpath ]]; then
         case $q in
             [A-Za-z]:\\*) q=$(printf '%s' "$q" | sed -e 's|^[A-Za-z]:||' -e 's|\\|/|g') ;;
         esac
     fi
-    if [ -f "$q" ]; then
+    if [[ -f "$q" ]]; then
         n=$((n + 1))
         grep -v 'UNFORMATTED' "$q" > "$q.stub" 2>/dev/null || true
         mv "$q.stub" "$q"
@@ -110,7 +131,8 @@ case $mode in
 esac
 exit 0
 STUB
-    chmod +x "$1/mvn"
+    chmod +x "$bindir/mvn"
+    return 0
 }
 
 # A fresh repo with the hook available. Sets: REPO, BIN, STUB_LOG.
@@ -129,11 +151,14 @@ new_repo() {
         git config commit.gpgsign false
         git config core.hooksPath .git/hooks
     )
+    return 0
 }
 
-java_file() { # path marker
-    mkdir -p "$REPO/$(dirname "$1")"
-    printf 'package p;\nclass C { }\n%s\n' "${2:-}" >"$REPO/$1"
+java_file() {
+    local path=$1 marker=${2:-}
+    mkdir -p "$REPO/$(dirname "$path")"
+    printf 'package p;\nclass C { }\n%s\n' "$marker" >"$REPO/$path"
+    return 0
 }
 
 # Run the hook the way git would, but under $TEST_BASH. Sets HOOK_RC, HOOK_OUT.
@@ -145,17 +170,22 @@ run_hook() {
             "$TEST_BASH" "$HOOK" >"$HOOK_OUT" 2>&1
     )
     HOOK_RC=$?
+    return 0
 }
 
 staged_content() { # path -> stdout
-    (cd "$REPO" && git show ":$1" 2>/dev/null)
+    local path=$1
+    (cd "$REPO" && git show ":$path" 2>/dev/null)
+    return 0
 }
 
 begin() {
-    CASE="$1"
+    local case_name=$1
+    CASE="$case_name"
     STUB_MODE=normal
-    printf '\n== %s\n' "$1"
+    printf '\n== %s\n' "$case_name"
     new_repo
+    return 0
 }
 
 # --- cases -------------------------------------------------------------------
@@ -164,7 +194,7 @@ begin no_java_staged
 echo hi >"$REPO/notes.txt"
 (cd "$REPO" && git add notes.txt)
 run_hook
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 assert_eq "$(wc -l <"$STUB_LOG" | tr -d ' ')" 0 'never invokes maven'
 
 begin nothing_staged
@@ -175,7 +205,7 @@ begin formats_and_restages
 java_file src/main/java/A.java UNFORMATTED
 (cd "$REPO" && git add src/main/java/A.java)
 run_hook
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 staged_content src/main/java/A.java >"$REPO/.idx"
 assert_not_contains "$REPO/.idx" UNFORMATTED 'index holds the formatted content'
 assert_not_contains "$REPO/src/main/java/A.java" UNFORMATTED 'worktree holds the formatted content'
@@ -190,7 +220,7 @@ java_file src/main/java/A.java UNFORMATTED
     printf 'package p;\nclass C { }\nUNFORMATTED\nSTAGED_EDIT\nSECRET_UNSTAGED\n' >src/main/java/A.java
 )
 run_hook
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 staged_content src/main/java/A.java >"$REPO/.idx"
 assert_not_contains "$REPO/.idx" SECRET_UNSTAGED 'unstaged line stays OUT of the index'
 assert_contains "$REPO/src/main/java/A.java" SECRET_UNSTAGED 'unstaged line survives in the worktree'
@@ -208,7 +238,7 @@ java_file src/main/java/Partial.java UNFORMATTED
     printf 'package p;\nclass C { }\nUNFORMATTED\ny\nEXTRA\n' >src/main/java/Partial.java
 )
 run_hook
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 staged_content src/main/java/Clean.java >"$REPO/.c"
 staged_content src/main/java/Partial.java >"$REPO/.p"
 assert_not_contains "$REPO/.c" UNFORMATTED 'clean file is formatted'
@@ -220,7 +250,7 @@ begin path_with_metachars
 java_file 'src/main/java/weird (x86)+dir/A.java' UNFORMATTED
 (cd "$REPO" && git add .)
 run_hook
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 assert_contains "$STUB_LOG" '\Q' 'passes a regex-quoted pattern'
 assert_contains "$STUB_LOG" 'weird (x86)+dir' 'pattern carries the literal directory name'
 assert_not_contains "$REPO/src/main/java/weird (x86)+dir/A.java" UNFORMATTED 'file with metachars is formatted'
@@ -229,7 +259,7 @@ begin filename_with_spaces
 java_file 'src/main/java/My Class.java' UNFORMATTED
 (cd "$REPO" && git add .)
 run_hook
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 assert_not_contains "$REPO/src/main/java/My Class.java" UNFORMATTED 'file with a space is formatted'
 
 begin path_with_comma_is_skipped
@@ -247,7 +277,7 @@ java_file src/main/java/Old.java UNFORMATTED
     git mv src/main/java/Old.java src/main/java/New.java
 )
 run_hook
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 assert_contains "$STUB_LOG" New.java 'a rename is offered to Spotless (ACMR, not ACM)'
 
 begin missing_maven_does_not_block
@@ -259,7 +289,7 @@ nomvn="$REPO/.nomvn"
 mkdir -p "$nomvn"
 for cmd in git awk uname cygpath; do
     real=$(command -v "$cmd" 2>/dev/null) || continue
-    [ -n "$real" ] || continue
+    [[ -n "$real" ]] || continue
     printf '#!/bin/sh\nexec "%s" "$@"\n' "$real" >"$nomvn/$cmd"
     chmod +x "$nomvn/$cmd"
 done
@@ -285,7 +315,7 @@ java_file src/main/java/A.java UNFORMATTED
 (cd "$REPO" && git add . && git commit -qm init --no-verify)
 (cd "$REPO" && printf 'package p;\nclass C { }\nUNFORMATTED\nz\n' >src/main/java/A.java && git add .)
 run_hook
-if [ "$HOOK_RC" -ne 0 ]; then ok 'blocks the commit when Spotless matched nothing'; else
+if [[ "$HOOK_RC" -ne 0 ]]; then ok 'blocks the commit when Spotless matched nothing'; else
     no 'blocks the commit when Spotless matched nothing (exited 0)'
 fi
 assert_contains "$HOOK_OUT" 'matched none' 'explains the no-op'
@@ -304,7 +334,7 @@ STUB_MODE=fail
 java_file src/main/java/A.java UNFORMATTED
 (cd "$REPO" && git add .)
 run_hook
-if [ "$HOOK_RC" -ne 0 ]; then ok 'blocks the commit when maven fails'; else
+if [[ "$HOOK_RC" -ne 0 ]]; then ok 'blocks the commit when maven fails'; else
     no 'blocks the commit when maven fails (exited 0)'
 fi
 assert_contains "$HOOK_OUT" 'stub maven failure' 'surfaces the maven output'
@@ -319,7 +349,7 @@ HOOK_OUT="$REPO/.hook-out"
             "$TEST_BASH" "$HOOK" >"$HOOK_OUT" 2>&1
 )
 HOOK_RC=$?
-assert_eq "$HOOK_RC" 0 'exits 0'
+assert_eq "$HOOK_RC" 0 "$EXITS_0"
 assert_not_contains "$REPO/src/main/java/deep/A.java" UNFORMATTED 'resolves the repo root from a subdirectory'
 
 # End to end: installed as a real hook and driven by `git commit`, so the shebang
@@ -377,6 +407,27 @@ assert_contains "$STUB_LOG" '\QC:\' 'builds a regex-quoted backslash Windows pat
 assert_contains "$STUB_LOG" 'MSYS2_ARG_CONV_EXCL=-DspotlessFiles' 'guards against MSYS argument mangling'
     assert_not_contains "$REPO/src/main/java/Program Files (x86)/A.java" UNFORMATTED \
         'formats a Windows-style path containing spaces and metacharacters'
+
+    begin windows_path_with_backslash_E
+    STUB_MODE=winpath
+    cat >"$BIN/uname" <<'FAKE_UNAME'
+#!/bin/sh
+echo MINGW64_NT-10.0-22631
+FAKE_UNAME
+    cat >"$BIN/cygpath" <<'FAKE_CYGPATH'
+#!/bin/sh
+last=''
+for a in "$@"; do last=$a; done
+printf '%s\n' "$last" | sed -e 's|^/|C:/|' -e 's|/|\\|g'
+FAKE_CYGPATH
+    chmod +x "$BIN/uname" "$BIN/cygpath"
+    java_file 'src/main/java/Eclipse/A.java' UNFORMATTED
+    (cd "$REPO" && git add .)
+    run_hook
+    assert_eq "$HOOK_RC" 0 'exits 0 on a path holding a literal \E'
+    assert_contains "$STUB_LOG" '\E\\E\Q' 'escapes the embedded \E the way Pattern.quote does'
+    assert_not_contains "$REPO/src/main/java/Eclipse/A.java" UNFORMATTED \
+        'formats a Windows path whose directory starts with E'
     ;;
 esac
 
@@ -387,7 +438,7 @@ esac
 # path handling above changes. Needs Maven, a JDK and (on a cold cache) the
 # network, hence opt-in. The plugin version is read from the parent POM so this
 # test cannot drift away from what the BOM ships.
-if [ "${E2E:-0}" = 1 ]; then
+if [[ "${E2E:-0}" = 1 ]]; then
     begin e2e_real_spotless
     SPOTLESS_VERSION=$(sed -n \
         's/.*<spotless-maven-plugin\.version>\([^<]*\)<.*/\1/p' "$HERE/../pom.xml" | head -1)
@@ -428,7 +479,7 @@ printf '\n--------------------------------------------------\n'
 printf 'bash under test: %s\n' "$("$TEST_BASH" -c 'echo $BASH_VERSION')"
 printf 'git:             %s\n' "$(git --version)"
 printf 'passed: %s   failed: %s\n' "$PASS" "$FAIL"
-if [ "$FAIL" -ne 0 ]; then
+if [[ "$FAIL" -ne 0 ]]; then
     printf 'failures:%s\n' "$FAILED_CASES"
     exit 1
 fi


### PR DESCRIPTION
Establishes one canonical Java style for the platform and enforces it from this parent POM, so a child repo opts in by bumping its parent version. Both gates bind to verify, which every child's CI already reaches, so no workflow YAML changes anywhere.

  Spotless    the whole style: indentation, wrapping, import order.
              `mvn spotless:apply` fixes every violation mechanically.
  Checkstyle  the four things Spotless cannot: AvoidStarImport, NeedBraces,
              UnusedImports, RedundantImport. These need hand-fixing.

The rules ship in a new com.otilm:build-tools module — Eclipse JDT formatter profile, import order, Checkstyle ruleset — so no repo copies them in. Both plugins read them off their PLUGIN classpath, which is why this POM now declares <pluginRepositories>: <repositories> cannot serve a plugin dependency, and none of the 21 org repos nor spring-boot-starter-parent declares one. Without it a child fails at plugin-realm construction, before any mojo reads a skip flag, which is also why spotless.skip cannot rescue it.

.editorconfig carries the IntelliJ-side mirror of the same style, hand-tuned against the pinned Eclipse JDT engine. Its ij_* names are IntelliJ's own export vocabulary and a misspelled one is silently ignored, so each was checked against the installed IDE rather than assumed: keep_blank_lines_before_rbrace exists, before_right_brace does not.

scripts/pre-commit.sh formats staged Java files before commit, and ships inside build-tools so children install it from the classpath with no per-repo file. It targets bash 3.2 (macOS system bash, which GUI git clients hand hooks) and Git Bash. Its contract is narrow on purpose: -DspotlessFiles is a REGEX matched against absolute paths, not a path list, so paths are \Q…\E-quoted and converted with cygpath on Windows; a partially staged file is reported and left alone rather than silently committed whole; a missing Maven warns instead of blocking; and a silent no-op blocks the commit rather than passing a file through unformatted. scripts/test-pre-commit.sh is its harness — 44 cases, plus 2 more driving the real plugin — green on macOS bash 3.2.57 and 5.3, Linux bash 3.2/4.4/5.2/5.3 across musl and glibc, and real Git Bash on windows-latest via the new hook-tests.yml.

Guards, each added because a probe showed the unguarded version breaking:
  - Hook installation is a profile keyed on .git, because the install goal hard-fails at initialize without a repository and several child repos build in Docker from just COPY src + COPY pom.xml.
  - The build-tools plugin dependency for that goal is confined to a child-only profile; declared unconditionally it broke a fresh offline clone of this repo at initialize, since build-tools is built by this same reactor.
  - The hook source is ${project.basedir}, not ${maven.multiModuleProjectDirectory}: the latter follows the working directory, so `cd build-tools && mvn -f ../pom.xml initialize` silently installed nothing.
  - Profile activation uses a dedicated .otilm-aggregator marker. Keying off build-tools/pom.xml would match any child containing a module of that name and silently disable its formatting gate.
  - Checkstyle sets excludeGeneratedSources, or the gate fails on generated sources a child cannot fix.
  - The shared rules live under otilm/ so a conventional root-level checkstyle.xml cannot shadow them by accident.
  - build-tools attaches a placeholder -javadoc.jar; it is resources-only, so javadoc:jar creates nothing and Central would have rejected the release after the tag was pushed.

Two smoke tests keep the rules themselves honest, because rules that are never executed drift silently. checkstyle:check stays bound in build-tools: with zero Java sources it still loads the ruleset from the jar it just built, so a bad rule name fails the build. The formatter-selftest module holds canonical fixtures over the constructs where the Eclipse and IntelliJ engines diverge most, so an edit to the profile that changes formatting fails before it can reach a child. Its POM records the mutation results, including what it does NOT catch. The module is excluded from both publishing paths.

Documents the rollout order in README.md and CLAUDE.md — reformat commit and .git-blame-ignore-revs first, parent bump last — since the reverse leaves a repo red in between, along with the escape hatches and the rule that checkstyle.xml stays at four rules.