### PR TITLE
Copy .editorconfig before the IDE hand-fixing step, not after

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,28 +88,8 @@ Escape hatches, in order of bluntness: `-Dspotless.skip=true`, `-Dcheckstyle.ski
 
 ### Rolling the gates out to a child repo
 
-Order matters — bumping the parent first leaves the repo red until the reformat lands, and the
-IDE config has to precede any hand-fixing:
-
-1. Copy in `.editorconfig` and `.gitattributes`. The parent POM cannot deliver these — they must
-   exist in the repo before the IDE or checkout honours them. A project already open needs a reload
-   to pick up a newly added `.editorconfig`.
-2. `mvn spotless:apply`, then hand-fix what Checkstyle reports.
-3. Commit that as a single mechanical reformat commit, touching nothing else — the two files from
-   step 1 stay uncommitted for now, so this commit can be blame-ignored wholesale.
-4. Record its SHA in a `.git-blame-ignore-revs` at the repo root and commit it; the `blame-ignore-revs`
-   profile then wires local `git blame` to skip it automatically (GitHub's web UI does this on
-   its own).
-5. Commit `.editorconfig` and `.gitattributes`.
-6. Only then bump `<parent>` to the version carrying the gates.
-
-**Existing Windows worktrees need a one-time line-ending refresh.** Checkout rewrites only the
-files a commit changed, so `.gitattributes` lands while the untouched files keep CRLF and
-Spotless rejects them — with `git status` reporting a clean tree throughout. Affects any worktree
-already holding CRLF files, including persistent Windows CI workspaces; only fresh clones and
-ephemeral CI are exempt. Diagnose with `git ls-files --eol -- "*.java"` (`i/lf` vs `w/crlf`). Fix
-per worktree: re-clone, or `git rm --cached -r .` followed by `git reset --hard` (discards
-uncommitted changes), or `mvn spotless:apply` (covers `src/{main,test}/java` only).
+The procedure is in `README.md` under "Rolling it out to an existing repo" — follow it there, in
+order, including the Windows line-ending note that follows it.
 
 ## Dependency Updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,16 +88,20 @@ Escape hatches, in order of bluntness: `-Dspotless.skip=true`, `-Dcheckstyle.ski
 
 ### Rolling the gates out to a child repo
 
-Order matters — bumping the parent first leaves the repo red until the reformat lands:
+Order matters — bumping the parent first leaves the repo red until the reformat lands, and the
+IDE config has to precede any hand-fixing:
 
-1. `mvn spotless:apply`, then hand-fix what Checkstyle reports.
-2. Commit that as a single mechanical reformat commit, touching nothing else.
-3. Record its SHA in a `.git-blame-ignore-revs` at the repo root; the `blame-ignore-revs`
+1. Copy in `.editorconfig` and `.gitattributes`. The parent POM cannot deliver these — they must
+   exist in the repo before the IDE or checkout honours them. A project already open needs a reload
+   to pick up a newly added `.editorconfig`.
+2. `mvn spotless:apply`, then hand-fix what Checkstyle reports.
+3. Commit that as a single mechanical reformat commit, touching nothing else — the two files from
+   step 1 stay uncommitted for now, so this commit can be blame-ignored wholesale.
+4. Record its SHA in a `.git-blame-ignore-revs` at the repo root; the `blame-ignore-revs`
    profile then wires local `git blame` to skip it automatically (GitHub's web UI does this on
    its own).
-4. Copy in `.editorconfig` and `.gitattributes`. The parent POM cannot deliver these — they must
-   exist in the repo before the IDE or checkout honours them.
-5. Only then bump `<parent>` to the version carrying the gates.
+5. Commit `.editorconfig` and `.gitattributes`.
+6. Only then bump `<parent>` to the version carrying the gates.
 
 **Existing Windows worktrees need a one-time line-ending refresh.** Checkout rewrites only the
 files a commit changed, so `.gitattributes` lands while the untouched files keep CRLF and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ IDE config has to precede any hand-fixing:
 2. `mvn spotless:apply`, then hand-fix what Checkstyle reports.
 3. Commit that as a single mechanical reformat commit, touching nothing else — the two files from
    step 1 stay uncommitted for now, so this commit can be blame-ignored wholesale.
-4. Record its SHA in a `.git-blame-ignore-revs` at the repo root; the `blame-ignore-revs`
+4. Record its SHA in a `.git-blame-ignore-revs` at the repo root and commit it; the `blame-ignore-revs`
    profile then wires local `git blame` to skip it automatically (GitHub's web UI does this on
    its own).
 5. Commit `.editorconfig` and `.gitattributes`.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ Linked worktrees work: Maven mirrors the hook into the shared hooks directory th
 
 **Do the reformat first and the version bump last.** In the other order your build is red in between.
 
-1. Bump the parent locally, without committing it.
-2. Run `mvn spotless:apply`.
-3. Run `mvn verify` and hand-fix what Checkstyle reports. Wildcard imports are the common one.
-4. Commit the result as a single mechanical reformat commit. Change nothing else in it.
-5. Create a `.git-blame-ignore-revs` at the repo root containing that commit's SHA. `git blame` then skips it, locally and in the GitHub UI.
-6. Copy `.editorconfig` and `.gitattributes` from this repo. The parent POM cannot deliver these — your IDE only honours files that exist in your own repo.
-7. Commit the parent bump.
+1. Copy `.editorconfig` and `.gitattributes` from this repo into the working tree. The parent POM cannot deliver these — your IDE and your checkout only honour files that exist in your own repo. If the project is already open, reload it — a newly added `.editorconfig` is not picked up automatically.
+2. Bump the parent locally, without committing it.
+3. Run `mvn spotless:apply`.
+4. Run `mvn verify` and hand-fix what Checkstyle reports. Wildcard imports are the common one.
+5. Commit the reformat as a single mechanical commit. Change nothing else in it — leave the two files from step 1 and the parent bump uncommitted for now, so this commit can be blame-ignored wholesale.
+6. Create a `.git-blame-ignore-revs` at the repo root containing that commit's SHA, and commit it. `git blame` then skips the reformat, locally and in the GitHub UI.
+7. Commit `.editorconfig` and `.gitattributes`.
+8. Commit the parent bump. This is what actually turns the gates on, so it goes last.
 
 ### Existing Windows worktrees need a one-time refresh
 
@@ -63,11 +64,11 @@ This hits any existing worktree that already contains CRLF files — commonly on
 
 Confirm it with `git ls-files --eol -- "*.java"`: an `i/lf` index entry against a `w/crlf` worktree entry is exactly the mismatch `git status` will not show you. Any one of these fixes it:
 
-| Fix | Scope | Cost |
-|-----|-------|------|
-| Delete the worktree and clone again | Every file | Loses uncommitted work, stashes and local branches |
-| `git rm --cached -r .` then `git reset --hard` | Every file | **Discards uncommitted changes** — commit or stash first |
-| `mvn spotless:apply` | `src/{main,test}/java` only | Leaves other text files on CRLF |
+| Fix                                            | Scope                       | Cost                                                     |
+|------------------------------------------------|-----------------------------|----------------------------------------------------------|
+| Delete the worktree and clone again            | Every file                  | Loses uncommitted work, stashes and local branches       |
+| `git rm --cached -r .` then `git reset --hard` | Every file                  | **Discards uncommitted changes** — commit or stash first |
+| `mvn spotless:apply`                           | `src/{main,test}/java` only | Leaves other text files on CRLF                          |
 
 The middle one is the usual choice. Run it once per worktree.
 


### PR DESCRIPTION
**The rollout order had `.editorconfig` arriving too late to do its job.**

Step 3 tells you to hand-fix the wildcard imports Checkstyle reports — IDE work — but `.editorconfig` only landed at step 6. At the exact moment the guard is needed, it is absent.

### This is not theoretical

IntelliJ collapses imports into a wildcard at **5 classes or 3 static members** by default, which is precisely what `AvoidStarImport` rejects. `.editorconfig` raises both thresholds to 999.

Rolling the gates out to `interfaces` (OmniTrustILM/interfaces#829) with the documented order: the IDE correctly fixed the 10 reported violations, then silently re-collapsed imports across **~49 other files** in the same pass. The violation count went 51 → 51, moving sideways instead of down, and the reformat commit had to be rebuilt. `git status` gives no hint — the files look legitimately edited.

The failure is quiet and self-inflicted by following the documented steps, which is the worst combination.

### The fix

The copy moves to **step 1**, before the project is opened, with a note that an already-open project needs a **reload** to pick up a newly added `.editorconfig` (IntelliJ does not watch for the file appearing — that cost a second round-trip during the same rollout).

Two smaller corrections follow from the renumbering:

- **The reformat commit stays pure.** `.editorconfig` and `.gitattributes` are now copied first but *committed* after the reformat, so the mechanical commit can still be blame-ignored wholesale without dragging config files into it. Copying and committing are separate acts; the old text conflated them.
- **The commit sequence is explicit end to end** — reformat, blame-ignore, config, parent bump — rather than implying the parent bump was the only thing left.

`CLAUDE.md` carries the same correction, since it has its own copy of the procedure with the same defect.

### Verification

Documentation only — no build impact. The corrected order is what OmniTrustILM/interfaces#829 actually followed on the second attempt, and it produced a clean result: 700 tests, Spotless clean across 1301 files, 0 Checkstyle violations.