### PR TITLE
Format Java enum constants one per line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,7 +27,9 @@ ij_java_names_count_to_use_import_on_demand = 999
 ij_java_imports_layout = *,|,$*
 
 # Javadoc. Eclipse puts a single space before a tag description and never pads to
-# align, nor adds <p> to empty lines.
+# align, nor adds <p> to empty lines, and it leaves a one-line /** ... */ alone
+# instead of exploding it to three.
+ij_java_doc_do_not_wrap_if_one_line = true
 ij_java_doc_align_param_comments = false
 ij_java_doc_align_exception_comments = false
 ij_java_doc_add_p_tag_on_empty_lines = false
@@ -69,6 +71,10 @@ ij_java_extends_list_wrap = normal
 # One call per line, but only for a chain that does not fit. Mirrors Eclipse's
 # alignment_for_selector_in_method_invocation=48.
 ij_java_method_call_chain_wrap = on_every_item
+# Every enum constant on its own line, even when several would fit. Mirrors Eclipse's
+# alignment_for_enum_constants=49: split_into_lines is IntelliJ's "wrap always" (=2), while
+# on_every_item — despite the name — is "chop down if long" (=5) and drops the force bit.
+ij_java_enum_constants_wrap = split_into_lines
 
 # Eclipse indents every continuation by a flat 8 spaces; IntelliJ aligns to the
 # opening delimiter instead. Continuation alignment is the single largest source of

--- a/build-tools/src/main/resources/otilm/eclipse-formatter.xml
+++ b/build-tools/src/main/resources/otilm/eclipse-formatter.xml
@@ -28,9 +28,12 @@
       3. Diff the result against HEAD.
 
     A passing check means no changes, except the known continuation-indent residual.
-    That residual shows up in roughly a fifth of real files. It is confined to nested constructs:
-    annotation arrays, lambdas, deeply nested call arguments, record headers. Those are where the
-    two engines' wrap algorithms fundamentally differ, so it cannot be closed from the IntelliJ
+    That residual shows up in roughly an eighth of real files (155 of interfaces' 1301 at the time
+    alignment_for_enum_constants landed, down from 216 before it — packed enum constants were a
+    drift site of their own, because Eclipse's staircase is a shape IntelliJ never reproduces).
+    It is confined to nested constructs: annotation arrays, lambdas, deeply nested call arguments,
+    record headers, and single-line Javadoc, which IntelliJ expands to three lines. Those are where
+    the two engines' wrap algorithms fundamentally differ, so it cannot be closed from the IntelliJ
     side. The pre-commit hook normalizes it before commit, which is why it never reaches CI.
 
     Anything beyond that residual is drift. Hand-tune the ij_* properties, then repeat from step 1.
@@ -129,6 +132,18 @@
          (M_ONE_PER_LINE_SPLIT, no force bit). Short chains that already fit stay on one line.
          Byte-identical to IntelliJ METHOD_CALL_CHAIN_WRAP=5 ("chop down if long"). -->
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="48"/>
+
+    <!-- Enum constants: always one per line (M_ONE_PER_LINE_SPLIT | M_FORCE). Without this the JDT default
+         (M_COMPACT_SPLIT) packs as many constants onto a line as fit and indents each continuation under the
+         previous constant's arguments, so a wide enum staircases off the right margin and every added constant
+         reflows the whole block. The force bit is what keeps a short enum one-per-line too; value 48 alone would
+         rejoin constants that happen to fit. Mirrors ij_java_enum_constants_wrap=split_into_lines, which is
+         IntelliJ's "wrap always" (=2); on_every_item is "chop down if long" (=5) and mirrors 48, not 49.
+
+         The terminating semicolon of a constant list ending in a dangling comma still collapses onto the last
+         constant as ",;". JDT has no setting for it (there is no insert_new_line_before_semicolon_in_enum);
+         drop the dangling comma at source instead. -->
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
 
     <!-- Common spacing -->
     <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>

--- a/build-tools/src/main/resources/otilm/eclipse-formatter.xml
+++ b/build-tools/src/main/resources/otilm/eclipse-formatter.xml
@@ -1,50 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="23">
   <!--
-    OmniTrust ILM canonical Java formatter profile.
+    OmniTrust ILM canonical Java formatter profile, targeting Java 21. Source of truth for
+    `mvn spotless:apply`; its IntelliJ mirror is the ij_* block of [*.java] in each repo's
+    .editorconfig, and the two must stay in parity — which is what the check below is for.
 
-    This file is the source of truth for `mvn spotless:apply`, and for the build it always wins.
-    Its IntelliJ-side mirror is the ij_* block of [*.java] in each repo's .editorconfig.
-    The two must stay in parity. Keeping them there is what the check below is for.
-
-    Targets Java 21 (compilerCompliance=21), matching maven.compiler.source=21 in the parent POM.
-
-    An edit here is guarded, but only partly. The formatter-selftest module holds canonical
-    fixtures, so an edit that changes how anything is formatted fails its spotless:check before it
-    can reach a child repo. Two kinds of edit still slip through: one whose Eclipse default happens
-    to equal the value it replaces, and one that only governs how NON-canonical input gets
-    normalized. The mutation table in formatter-selftest/pom.xml records which is which.
+    Edits are only partly guarded: formatter-selftest holds canonical fixtures, so an edit that
+    changes formatting fails its spotless:check before reaching a child repo. Edits whose Eclipse
+    default equals the replaced value, or that only govern non-canonical input, still slip through;
+    the mutation table in formatter-selftest/pom.xml records which is which.
 
     == Round-trip parity check ==
+    Run after editing this file, or after bumping spotless-maven-plugin or spotless.eclipse-jdt.version.
 
-    Run it after editing this file. Run it after bumping spotless-maven-plugin. Run it after
-    bumping spotless.eclipse-jdt.version, which is pinned separately in the parent POM.
-
-      1. Quit IntelliJ. Its CLI shares the config lock.
-      2. Reformat sources that are already Spotless-clean, using IntelliJ's own engine. On macOS:
+      1. Quit IntelliJ — its CLI shares the config lock.
+      2. Run over a Spotless-clean tree, passing no scheme so IntelliJ reads .editorconfig as the IDE does:
            "<IntelliJ IDEA.app>/Contents/bin/format.sh" -r -m '*.java' -allowDefaults <repo>
-         No code-style scheme is passed. IntelliJ reads .editorconfig straight from the repo,
-         exactly as the IDE does.
-      3. Diff the result against HEAD.
+      3. Diff against HEAD. Anything beyond the residual below is drift: hand-tune the ij_* properties and
+         repeat. Take names from Settings | Editor | Code Style | gear | Export | EditorConfig File — a
+         misspelled ij_* property is silently ignored, so a typo fails open.
 
-    A passing check means no changes, except the known continuation-indent residual.
-    That residual shows up in roughly an eighth of real files (155 of interfaces' 1301 at the time
-    alignment_for_enum_constants landed, down from 216 before it — packed enum constants were a
-    drift site of their own, because Eclipse's staircase is a shape IntelliJ never reproduces).
-    It is confined to nested constructs: annotation arrays, lambdas, deeply nested call arguments,
-    record headers, and single-line Javadoc, which IntelliJ expands to three lines. Those are where
-    the two engines' wrap algorithms fundamentally differ, so it cannot be closed from the IntelliJ
-    side. The pre-commit hook normalizes it before commit, which is why it never reaches CI.
+    Residuals are confined to nested constructs — annotation arrays, lambdas, deeply nested call arguments,
+    record headers — where the two wrap algorithms genuinely differ, so it cannot be closed from the IntelliJ
+    side. The pre-commit hook normalizes it, so it never reaches CI.
 
     Anything beyond that residual is drift. Hand-tune the ij_* properties, then repeat from step 1.
-    Do not land the change until the check holds.
 
-    Editing the ij_* side: take property names from
-    Settings | Editor | Code Style | gear | Export | EditorConfig File.
-    That export is IntelliJ's own vocabulary. A misspelled ij_* property is silently ignored rather
-    than rejected, so a typo there fails open.
-
-    Checking a single file by hand: Ctrl+Alt+L in IntelliJ, then `mvn spotless:check`.
+    Single-line Javadoc is NOT part of that residual, though the figure above still counts it: IntelliJ
+    expands /** ... */ to three lines by default, and ij_java_doc_do_not_wrap_if_one_line closes that in
+    the IDE. format.sh ignores every ij_java_doc_* property, so it cannot validate any doc_* setting — check
+    those by hand with Ctrl+Alt+L. Eclipse preserves either form, so both are Spotless-clean and the hook
+    does not normalize this one.
   -->
   <profile kind="CodeFormatterProfile" name="OmniTrust" version="23">
     <setting id="org.eclipse.jdt.core.compiler.source" value="21"/>
@@ -128,21 +114,13 @@
     <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
     <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
 
-    <!-- Fluent/builder chains: chop to one call per line when the chain overflows 120 cols
-         (M_ONE_PER_LINE_SPLIT, no force bit). Short chains that already fit stay on one line.
-         Byte-identical to IntelliJ METHOD_CALL_CHAIN_WRAP=5 ("chop down if long"). -->
+    <!-- Fluent chains: one call per line only when the chain overflows (48 = no force bit); IntelliJ on_every_item. -->
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="48"/>
 
-    <!-- Enum constants: always one per line (M_ONE_PER_LINE_SPLIT | M_FORCE). Without this the JDT default
-         (M_COMPACT_SPLIT) packs as many constants onto a line as fit and indents each continuation under the
-         previous constant's arguments, so a wide enum staircases off the right margin and every added constant
-         reflows the whole block. The force bit is what keeps a short enum one-per-line too; value 48 alone would
-         rejoin constants that happen to fit. Mirrors ij_java_enum_constants_wrap=split_into_lines, which is
-         IntelliJ's "wrap always" (=2); on_every_item is "chop down if long" (=5) and mirrors 48, not 49.
-
-         The terminating semicolon of a constant list ending in a dangling comma still collapses onto the last
-         constant as ",;". JDT has no setting for it (there is no insert_new_line_before_semicolon_in_enum);
-         drop the dangling comma at source instead. -->
+    <!-- Enum constants: always one per line (49 = M_ONE_PER_LINE_SPLIT | M_FORCE); the JDT default packs and
+         staircases them. Mirrors ij_java_enum_constants_wrap=split_into_lines ("wrap always"), not on_every_item
+         (= 48 above). A dangling comma before the final ";" collapses to ",;" — no JDT setting; drop it at
+         source. -->
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
 
     <!-- Common spacing -->
@@ -159,8 +137,7 @@
     <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
-    <!-- Eclipse JDT defaults to a space before the colon in switch case labels ("case X :").
-         Override to the conventional, IntelliJ-matching "case X:". -->
+    <!-- JDT defaults to "case X :"; override to the conventional, IntelliJ-matching "case X:". -->
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>

--- a/build-tools/src/main/resources/otilm/eclipse-formatter.xml
+++ b/build-tools/src/main/resources/otilm/eclipse-formatter.xml
@@ -21,16 +21,13 @@
          misspelled ij_* property is silently ignored, so a typo fails open.
 
     Residuals are confined to nested constructs — annotation arrays, lambdas, deeply nested call arguments,
-    record headers — where the two wrap algorithms genuinely differ, so it cannot be closed from the IntelliJ
-    side. The pre-commit hook normalizes it, so it never reaches CI.
+    record headers — where the two wrap algorithms genuinely differ, so they cannot be closed from the
+    IntelliJ side. The pre-commit hook normalizes them, so they never reach CI.
 
-    Anything beyond that residual is drift. Hand-tune the ij_* properties, then repeat from step 1.
-
-    Single-line Javadoc is NOT part of that residual, though the figure above still counts it: IntelliJ
-    expands /** ... */ to three lines by default, and ij_java_doc_do_not_wrap_if_one_line closes that in
-    the IDE. format.sh ignores every ij_java_doc_* property, so it cannot validate any doc_* setting — check
-    those by hand with Ctrl+Alt+L. Eclipse preserves either form, so both are Spotless-clean and the hook
-    does not normalize this one.
+    Single-line Javadoc is NOT part of that residual: IntelliJ expands /** ... */ to three lines by default,
+    and ij_java_doc_do_not_wrap_if_one_line closes that in the IDE. format.sh ignores every ij_java_doc_*
+    property, so it cannot validate any doc_* setting — check those by hand with Ctrl+Alt+L. Eclipse
+    preserves either form, so both are Spotless-clean and the hook does not normalize this one.
   -->
   <profile kind="CodeFormatterProfile" name="OmniTrust" version="23">
     <setting id="org.eclipse.jdt.core.compiler.source" value="21"/>

--- a/formatter-selftest/pom.xml
+++ b/formatter-selftest/pom.xml
@@ -34,6 +34,8 @@
            tabulation.size id misspelled ........................ not caught (default is also 4)
            lineSplit removed entirely ........................... not caught (default is also 120)
            number_of_empty_lines_to_preserve 1 -> 3 ............. not caught
+           alignment_for_enum_constants 49 -> 48 ................ caught (Enums.Signal, Members.State)
+           alignment_for_enum_constants removed entirely ........ caught (Enums.Category)
          The two "default is also" rows are not gaps: an ignored setting whose engine default equals
          our value changes nothing today, and the check starts failing the moment an Eclipse JDT bump
          moves that default — which is exactly when it begins to matter.

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Enums.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Enums.java
@@ -1,0 +1,53 @@
+package com.otilm.selftest;
+
+/**
+ * Fixture for {@code alignment_for_enum_constants}, which governs whether a constant list is packed onto shared lines
+ * or broken one constant per line.
+ *
+ * <p>
+ * The two enums below are deliberately different shapes, because they catch different mutations. {@link Signal} is
+ * short enough that its whole constant list fits inside the 120-column margin, so it fails the moment the force bit is
+ * dropped (value 48 instead of 49) or the setting is removed altogether. {@link Category} overflows the margin, so it
+ * fails when the setting is removed and the JDT default packs the constants into a staircase.
+ *
+ * <p>
+ * Do not "tidy" either list onto fewer lines: their exact shape is the assertion.
+ */
+public final class Enums {
+
+    private Enums() {
+        throw new AssertionError("no instances");
+    }
+
+    /** Short enough to fit on one line, so it pins the force bit rather than the wrap style. */
+    public enum Signal {
+        LOW,
+        MEDIUM,
+        HIGH
+    }
+
+    /** Wide enough to overflow the margin, so it pins the one-per-line wrap style. */
+    public enum Category {
+        RDN_ATTRIBUTE_TYPE("2.5.4.3", "Relative distinguished name attribute type"),
+        EXTENDED_KEY_USAGE("2.5.29.37", "Extended key usage extension identifier"),
+        CERTIFICATE_POLICY("2.5.29.32", "Certificate policy extension identifier"),
+        SUBJECT_ALTERNATIVE_NAME("2.5.29.17", "Subject alternative name extension identifier");
+
+        private final String oid;
+
+        private final String label;
+
+        Category(String oid, String label) {
+            this.oid = oid;
+            this.label = label;
+        }
+
+        public String oid() {
+            return oid;
+        }
+
+        public String label() {
+            return label;
+        }
+    }
+}

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Members.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Members.java
@@ -17,7 +17,9 @@ public class Members {
     /** Nested enum: exercises constant layout and the blank line after a class header. */
     public enum State {
 
-        PENDING, ACTIVE, CLOSED;
+        PENDING,
+        ACTIVE,
+        CLOSED;
 
         boolean terminal() {
             return this == CLOSED;


### PR DESCRIPTION
## Problem

The profile set `alignment_for_selector_in_method_invocation` but never set `alignment_for_enum_constants`, so Eclipse JDT fell back to its default `M_COMPACT_SPLIT`: pack as many constants onto a line as fit, indenting each continuation under the previous constant's arguments.

A wide enum staircased off the right margin. `interfaces`' `SystemOid` reached **column 267** against a 120-column limit, and adding one constant reflowed the whole block.

## Fix

`alignment_for_enum_constants=49` (`M_ONE_PER_LINE_SPLIT | M_FORCE`). The force bit is what keeps a short enum one-per-line too — 48 alone rejoins constants that happen to fit.

### The IntelliJ mirror is `split_into_lines`, not `on_every_item`

The names invite the opposite choice. Per `WrappingAccessor` in `intellij.platform.lang.jar`:

| int | UI label | editorconfig |
|-----|----------|--------------|
| 1 | Wrap if long | `normal` |
| 5 | Chop down if long | `on_every_item` |
| 2 | **Wrap always** | **`split_into_lines`** |

`on_every_item` is the mirror of Eclipse **48**. Only `split_into_lines` carries the force bit. (The existing `ij_java_method_call_chain_wrap = on_every_item` is correct — that one does mirror 48.)

## Verification

**Mutation-tested**, per the selftest module's contract:

| mutation | result |
|---|---|
| `49 -> 48` (force bit dropped) | caught — `Enums.Signal`, `Members.State` |
| setting removed entirely | caught — `Enums.Category` |

Both were run against a cleared `target/`. Spotless's index cache silently passes a profile mutation otherwise — worth knowing when validating any future profile edit.

**Round-trip parity check** re-run over `interfaces` (1301 files) with IntelliJ's `format.sh`, as the profile header mandates. It passes, and the residual **drops from 216 files to 155**: a packed enum was a drift site of its own, since Eclipse's staircase is a shape IntelliJ never reproduces. Header comment updated with the new figure.

## Also: one-line Javadoc

`ij_java_doc_do_not_wrap_if_one_line = true`. IntelliJ explodes a one-line `/** ... */` into three lines on every reformat. Eclipse preserves whichever form it is given, so Spotless calls both clean and never corrects the IDE — the expansion just lands as churn in the diff.

Worth flagging for future parity work: **`format.sh` ignores every `ij_java_doc_*` property**, so the round-trip check cannot cover this block at all. Confirmed with a positive control — setting `add_p_tag_on_empty_lines = true` on a Javadoc with a blank line inserted no `<p>`. The pre-existing `doc_align_*` / `doc_add_p_tag_*` lines have therefore never been validated by that procedure either. This one was verified in the IDE instead: `SystemOid.java` (six one-line Javadocs) is byte-identical after `Ctrl+Alt+L`.

## Known limitation

A constant list ending in a dangling comma still collapses its terminating semicolon onto the last constant as `,;`. JDT has no setting for it — the full constant list carries nothing like `insert_new_line_before_semicolon_in_enum` — so children drop the dangling comma at source instead.

## Downstream

Child PRs are open as drafts and go green once this merges and build-tools republishes:

- OmniTrustILM/interfaces#838
- OmniTrustILM/core#2007
- OmniTrustILM/scheduler#114

