### PR TITLE
Chop annotation member arrays and wrap annotation arguments

### DIFF
--- a/build-tools/src/main/resources/otilm/eclipse-formatter.xml
+++ b/build-tools/src/main/resources/otilm/eclipse-formatter.xml
@@ -67,6 +67,22 @@
     <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
     <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
 
+    <!-- Array initializers, including annotation member values: Eclipse has exactly one alignment option for both,
+         so any rule chosen here applies equally to @ApiResponses({...}) and to new byte[]{1, 2, 3}.
+
+         48 is "one element per line" WITHOUT the force bit. A long annotation array is chopped one element per line;
+         a short byte[] or int[] literal is left alone. 49 was rejected precisely because the force bit cannot tell
+         those two apart and explodes every array literal in the test sources.
+
+         The two insert_new_line_*_brace_in_array_initializer settings are deliberately NOT set as they are
+         unconditional.
+
+         IntelliJ parity: partial, and asymmetric by design. There is no IDE setting that reproduces 48. The mirror
+         therefore stays at the default ij_java_array_initializer_wrap = normal, which yields: IntelliJ does not CREATE
+         the chopped shape on freshly typed code, but it does PRESERVE it once Spotless has applied it. Do not "fix"
+         this by adding the two ij_* brace properties. -->
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="48"/>
+
     <!-- Blank lines -->
     <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
     <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
@@ -119,6 +135,15 @@
          (= 48 above). A dangling comma before the final ";" collapses to ",;" — no JDT setting; drop it at
          source. -->
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+
+    <!-- Annotation arguments. 16 is "wrap only where necessary", the mildest value that lets JDT break at all.
+         It moves the argument onto its own continuation line, the line comes in under 120, and IntelliJ then has nothing
+         to rescue and leaves it alone.
+
+         The drift that remains is a literal-length problem, not a wrapping one: where a single string literal
+         is itself wider than the margin, JDT correctly declines to break (it would not help) while IntelliJ
+         breaks anyway. Only shortening the literal at source closes those. -->
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
 
     <!-- Common spacing -->
     <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>

--- a/build-tools/src/main/resources/otilm/eclipse-formatter.xml
+++ b/build-tools/src/main/resources/otilm/eclipse-formatter.xml
@@ -71,8 +71,8 @@
          so any rule chosen here applies equally to @ApiResponses({...}) and to new byte[]{1, 2, 3}.
 
          48 is "one element per line" WITHOUT the force bit. A long annotation array is chopped one element per line;
-         a short byte[] or int[] literal is left alone. 49 was rejected precisely because the force bit cannot tell
-         those two apart and explodes every array literal in the test sources.
+         a short byte[] or int[] literal is left alone. The force bit cannot distinguish those two cases, so 49
+         explodes every array literal in the test sources.
 
          The two insert_new_line_*_brace_in_array_initializer settings are deliberately NOT set as they are
          unconditional.

--- a/formatter-selftest/pom.xml
+++ b/formatter-selftest/pom.xml
@@ -28,21 +28,21 @@
          profile still produces exactly them, so a change that alters formatting fails HERE, before
          it can be published. Mutation-tested; the results define what this module does and does not
          cover:
-           tabulation.char space -> tab ......................... caught
-           lineSplit 120 -> 100 ................................. caught
-           tabulation.char id misspelled ........................ caught (default is tab)
-           tabulation.size id misspelled ........................ not caught (default is also 4)
-           lineSplit removed entirely ........................... not caught (default is also 120)
-           number_of_empty_lines_to_preserve 1 -> 3 ............. not caught
-           alignment_for_enum_constants 49 -> 48 ................ caught (Enums.Signal, Members.State)
-           alignment_for_enum_constants removed entirely ........ caught (Enums.Category)
-           alignment_for_expr_in_array_initializer 48 -> 49 ..... caught (Annotations ONLY)
-           alignment_for_expr_in_array_initializer 48 -> 16 ..... caught (Annotations, Wrapping.names)
-           alignment_for_expr_in_array_initializer removed ...... caught (Annotations, Wrapping.names)
-           insert_new_line_before_closing_brace_in_array added .. caught (Annotations, Wrapping.names)
-           alignment_for_arguments_in_annotation removed ........ caught (Annotations ONLY)
-           alignment_for_arguments_in_annotation 16 -> 32 ....... caught (Annotations ONLY)
-           alignment_for_assignment added ....................... caught (Wrapping.chainInTheAssignmentWindow ONLY)
+           tabulation.char space -> tab ..................................... caught
+           lineSplit 120 -> 100 ............................................. caught
+           tabulation.char id misspelled .................................... caught (default is tab)
+           tabulation.size id misspelled .................................... not caught (default is also 4)
+           lineSplit removed entirely ....................................... not caught (default is also 120)
+           number_of_empty_lines_to_preserve 1 -> 3 ......................... not caught
+           alignment_for_enum_constants 49 -> 48 ............................ caught (Enums.Signal, Members.State)
+           alignment_for_enum_constants removed entirely .................... caught (Enums.Category)
+           alignment_for_expressions_in_array_initializer 48 -> 49 .......... caught (Annotations ONLY)
+           alignment_for_expressions_in_array_initializer 48 -> 16 .......... caught (Annotations, Wrapping.names)
+           alignment_for_expressions_in_array_initializer removed ........... caught (Annotations, Wrapping.names)
+           insert_new_line_before_closing_brace_in_array_initializer added .. caught (Annotations, Wrapping.names)
+           alignment_for_arguments_in_annotation removed .................... caught (Annotations ONLY)
+           alignment_for_arguments_in_annotation 16 -> 32 ................... caught (Annotations ONLY)
+           alignment_for_assignment added ................................... caught (Wrapping.chainInTheAssignmentWindow ONLY)
          The two "default is also" rows are not gaps: an ignored setting whose engine default equals
          our value changes nothing today, and the check starts failing the moment an Eclipse JDT bump
          moves that default — which is exactly when it begins to matter.

--- a/formatter-selftest/pom.xml
+++ b/formatter-selftest/pom.xml
@@ -28,7 +28,7 @@
          profile still produces exactly them, so a change that alters formatting fails HERE, before
          it can be published. Mutation-tested; the results define what this module does and does not
          cover:
-           tabulation.char space -> tab .......................... caught
+           tabulation.char space -> tab ......................... caught
            lineSplit 120 -> 100 ................................. caught
            tabulation.char id misspelled ........................ caught (default is tab)
            tabulation.size id misspelled ........................ not caught (default is also 4)
@@ -42,29 +42,10 @@
            insert_new_line_before_closing_brace_in_array added .. caught (Annotations, Wrapping.names)
            alignment_for_arguments_in_annotation removed ........ caught (Annotations ONLY)
            alignment_for_arguments_in_annotation 16 -> 32 ....... caught (Annotations ONLY)
-           alignment_for_assignment added ...................... caught (Wrapping.chainInTheAssignmentWindow ONLY)
+           alignment_for_assignment added ....................... caught (Wrapping.chainInTheAssignmentWindow ONLY)
          The two "default is also" rows are not gaps: an ignored setting whose engine default equals
          our value changes nothing today, and the check starts failing the moment an Eclipse JDT bump
          moves that default — which is exactly when it begins to matter.
-         The "Annotations ONLY" row is why that fixture exists. Adding the force bit to the array
-         alignment leaves every over-margin construct in Wrapping unchanged and only rewrites arrays
-         that already fit — short byte[] literals in tests, and short annotation member arrays. No
-         over-margin fixture can see it, so without Annotations that regression ships silently.
-         The two wrapping settings at the bottom of the table guard against a specific failure mode:
-         at their JDT default of 0 the formatter emits over-margin lines rather than wrapping, which
-         IntelliJ then rewrites on its own — so the drift appears in the IDE, never in CI, and no
-         amount of checking the build catches it. Each is pinned by exactly one fixture; keep the
-         over-margin annotation in Annotations and the sized chain in Wrapping intact.
-         The "assignment added" row is the inverse: that setting is one we must NOT adopt, because
-         wrapping after the '=' frees enough width to un-chop a fluent chain. Only a chain that
-         overflows by less than that gained width can see it — describe()'s longer chain stays chopped
-         either way and reports nothing. chainInTheAssignmentWindow is sized to sit in exactly that
-         window, so renaming its variable or editing its chain silently disarms the guard.
-         The number_of_empty_lines_to_preserve row IS a real limit. A setting that only governs how
-         NON-canonical input is normalised (collapsing blank runs, rewrapping over-long lines) cannot
-         be exercised by a fixture that is already canonical. Covering those needs a second,
-         deliberately misformatted fixture set plus an expected-output comparison, which this module
-         does not have.
          The module depends on nothing and has no unit tests: the gate is the assertion. Ordered
          after build-tools in the parent's <modules> so Spotless resolves the rules from the reactor
          rather than from a repository. -->

--- a/formatter-selftest/pom.xml
+++ b/formatter-selftest/pom.xml
@@ -36,13 +36,35 @@
            number_of_empty_lines_to_preserve 1 -> 3 ............. not caught
            alignment_for_enum_constants 49 -> 48 ................ caught (Enums.Signal, Members.State)
            alignment_for_enum_constants removed entirely ........ caught (Enums.Category)
+           alignment_for_expr_in_array_initializer 48 -> 49 ..... caught (Annotations ONLY)
+           alignment_for_expr_in_array_initializer 48 -> 16 ..... caught (Annotations, Wrapping.names)
+           alignment_for_expr_in_array_initializer removed ...... caught (Annotations, Wrapping.names)
+           insert_new_line_before_closing_brace_in_array added .. caught (Annotations, Wrapping.names)
+           alignment_for_arguments_in_annotation removed ........ caught (Annotations ONLY)
+           alignment_for_arguments_in_annotation 16 -> 32 ....... caught (Annotations ONLY)
+           alignment_for_assignment added ...................... caught (Wrapping.chainInTheAssignmentWindow ONLY)
          The two "default is also" rows are not gaps: an ignored setting whose engine default equals
          our value changes nothing today, and the check starts failing the moment an Eclipse JDT bump
          moves that default — which is exactly when it begins to matter.
-         The last row IS a real limit. A setting that only governs how NON-canonical input is
-         normalised (collapsing blank runs, rewrapping over-long lines) cannot be exercised by a
-         fixture that is already canonical. Covering those needs a second, deliberately misformatted
-         fixture set plus an expected-output comparison, which this module does not have.
+         The "Annotations ONLY" row is why that fixture exists. Adding the force bit to the array
+         alignment leaves every over-margin construct in Wrapping unchanged and only rewrites arrays
+         that already fit — short byte[] literals in tests, and short annotation member arrays. No
+         over-margin fixture can see it, so without Annotations that regression ships silently.
+         The two wrapping settings at the bottom of the table guard against a specific failure mode:
+         at their JDT default of 0 the formatter emits over-margin lines rather than wrapping, which
+         IntelliJ then rewrites on its own — so the drift appears in the IDE, never in CI, and no
+         amount of checking the build catches it. Each is pinned by exactly one fixture; keep the
+         over-margin annotation in Annotations and the sized chain in Wrapping intact.
+         The "assignment added" row is the inverse: that setting is one we must NOT adopt, because
+         wrapping after the '=' frees enough width to un-chop a fluent chain. Only a chain that
+         overflows by less than that gained width can see it — describe()'s longer chain stays chopped
+         either way and reports nothing. chainInTheAssignmentWindow is sized to sit in exactly that
+         window, so renaming its variable or editing its chain silently disarms the guard.
+         The number_of_empty_lines_to_preserve row IS a real limit. A setting that only governs how
+         NON-canonical input is normalised (collapsing blank runs, rewrapping over-long lines) cannot
+         be exercised by a fixture that is already canonical. Covering those needs a second,
+         deliberately misformatted fixture set plus an expected-output comparison, which this module
+         does not have.
          The module depends on nothing and has no unit tests: the gate is the assertion. Ordered
          after build-tools in the parent's <modules> so Spotless resolves the rules from the reactor
          rather than from a repository. -->

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Annotations.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Annotations.java
@@ -42,7 +42,11 @@ public final class Annotations {
     public static void singleElement() {
     }
 
-    /** Empty member array, which keep_empty_array_initializer_on_one_line holds together. */
+    /**
+     * Empty member array, held together by keep_empty_array_initializer_on_one_line. That setting is not in the profile
+     * and so is not mutation-tested: this fixture pins the Eclipse default, and will start failing if a JDT bump ever
+     * moves it.
+     */
     @Responses({})
     public static void noElements() {
     }

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Annotations.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Annotations.java
@@ -1,0 +1,98 @@
+package com.otilm.selftest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Fixture for the array-initializer settings as they show up in an annotation's brace-delimited member value. Eclipse
+ * formats an annotation member array with the same rules as a plain array initializer, so this fixture and the String[]
+ * field in {@link Wrapping} guard the same three settings from opposite ends.
+ *
+ * <p>
+ * The methods are empty and unreachable by design; only the source shape is the assertion. Do not "tidy" the layout —
+ * it is what spotless:apply produces, and any hand edit will be reported as a violation on the next check.
+ */
+public final class Annotations {
+
+    private Annotations() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Several elements, together well over the margin.
+     */
+    @Responses({
+            @Response(status = 200, description = "Supported key usages retrieved"),
+            @Response(status = 422, description = "Request validation failed",
+                    content = @Content(mediaType = "application/problem+json", schema = "ProblemDetailExtended"))})
+    public static void multipleElementsOverMargin() {
+    }
+
+    /**
+     * Several elements that fit comfortably.
+     */
+    @Responses({@Response(status = 200), @Response(status = 404)})
+    public static void multipleElementsUnderMargin() {
+    }
+
+    /** One short element, left inline — the shape a forced alignment or an unconditional brace setting would break. */
+    @Responses({@Response(status = 204, description = "no content")})
+    public static void singleElement() {
+    }
+
+    /** Empty member array, which keep_empty_array_initializer_on_one_line holds together. */
+    @Responses({})
+    public static void noElements() {
+    }
+
+    /**
+     * These literals carry no annotation and are nowhere near the margin, so they must survive untouched.
+     */
+    public static byte[] shortLiteralsStayIntact() {
+        int[] triple = {1, 2, 3};
+        return new byte[]{(byte) triple[0], (byte) triple[1], (byte) triple[2]};
+    }
+
+    /**
+     * Two arguments whose combined length passes the margin.
+     */
+    @Doc(name = "Discovery Operations",
+            description = "Stateless run lifecycle: initiate a run, poll or stream its results, and control "
+                    + "it. Every call carries the full context; the connector holds no state between calls.")
+    public static void annotationArgumentsOverMargin() {
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @Target(ElementType.METHOD)
+    private @interface Doc {
+        String name();
+
+        String description();
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @Target(ElementType.METHOD)
+    private @interface Responses {
+        Response[] value();
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @Target({})
+    private @interface Response {
+        int status();
+
+        String description() default "";
+
+        Content content() default @Content;
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @Target({})
+    private @interface Content {
+        String mediaType() default "";
+
+        String schema() default "";
+    }
+}

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Wrapping.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Wrapping.java
@@ -37,7 +37,7 @@ public final class Wrapping {
     /**
      * A fluent chain in the narrow window that only alignment_for_assignment can break: it overflows the margin by less
      * than the 8 columns that wrapping after the '=' would buy. Setting alignment_for_assignment therefore frees just
-     * enough width for the whole chain to fit. Do not shorten this field's name or its chain.
+     * enough width for the whole chain to fit. Do not shorten the {@code result} local or its chain.
      */
     public static List<String> chainInTheAssignmentWindow(List<String> values) {
         List<String> result = values

--- a/formatter-selftest/src/main/java/com/otilm/selftest/Wrapping.java
+++ b/formatter-selftest/src/main/java/com/otilm/selftest/Wrapping.java
@@ -20,8 +20,35 @@ public final class Wrapping {
             .of("alpha", List.of("one", "two", "three"), "beta", List.of("four", "five", "six"), "gamma",
                     List.of("seven", "eight", "nine"));
 
-    private final String[] names = {"first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth",
-            "ninth"};
+    private final String[] names = {
+            "first",
+            "second",
+            "third",
+            "fourth",
+            "fifth",
+            "sixth",
+            "seventh",
+            "eighth",
+            "ninth",
+            "tenth",
+            "eleventh",
+            "twelfth"};
+
+    /**
+     * A fluent chain in the narrow window that only alignment_for_assignment can break: it overflows the margin by less
+     * than the 8 columns that wrapping after the '=' would buy. Setting alignment_for_assignment therefore frees just
+     * enough width for the whole chain to fit. Do not shorten this field's name or its chain.
+     */
+    public static List<String> chainInTheAssignmentWindow(List<String> values) {
+        List<String> result = values
+                .stream()
+                .map(String::strip)
+                .filter(value -> !value.isEmpty())
+                .sorted()
+                .distinct()
+                .toList();
+        return result;
+    }
 
     private Wrapping() {
         throw new AssertionError("no instances");


### PR DESCRIPTION
Two settings added to the canonical Eclipse profile.

`alignment_for_expressions_in_array_initializer = 48` — an annotation member array such as `@ApiResponses({...})` is chopped one element per line once it passes the margin. 48 (no force bit) rather than 49, so short literals like `new byte[]{1, 2, 3}` stay inline.

`alignment_for_arguments_in_annotation = 16` — an over-margin annotation argument moves to its own continuation line. Previously JDT never wrapped these and emitted lines well over the margin, which IntelliJ then rewrote by breaking after the `=`; that was the largest single source of IDE-vs-build drift.

`alignment_for_assignment` was evaluated and rejected: it frees enough width to un-chop fluent builder chains. `Wrapping.chainInTheAssignmentWindow` is sized to fail if anyone re-adds it.

New `Annotations` fixture plus additions to `Wrapping`; all settings mutation-tested, results recorded in the `formatter-selftest` table.

**Merge this first** — `build-tools` only republishes on push to `main`, so the interfaces / core / scheduler PRs will fail `spotless:check` in CI until this is merged and published.